### PR TITLE
fix: set docarray version to avoid changes

### DIFF
--- a/requirements_pip.txt
+++ b/requirements_pip.txt
@@ -10,3 +10,4 @@ py-cpuinfo==8.0.0
 kubernetes==23.3.0
 prompt_toolkit==3.0.28
 protobuf==3.19.4
+docarray==0.10.2


### PR DESCRIPTION
As mentioned in the issue #47, it seems that the dataset files have to re-created to overcome the latest docarray changes. However to avoid that, for now we will set the docarray version. Ticket to remain open for future implementation