### PR TITLE
Fix protobuf version

### DIFF
--- a/deployment/bff/requirements.txt
+++ b/deployment/bff/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 uvloop
 pydantic
 jina[perf]==3.4.4
+protobuf~=3.19

--- a/deployment/playground/requirements.txt
+++ b/deployment/playground/requirements.txt
@@ -5,3 +5,4 @@ streamlit-webrtc==0.36.1
 better_profanity==0.7.0
 docarray==0.10.2
 pydantic==1.8.2
+protobuf~=3.19

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -14,7 +14,7 @@ from now.log.log import yaspin_extended
 from now.system_information import get_system_state
 from now.utils import sigmap
 
-docker_bff_playground_tag = '0.0.42'
+docker_bff_playground_tag = '0.0.43'
 
 
 def get_remote_flow_details():


### PR DESCRIPTION
Protobuf errors occurs currently in bff and playground. Following https://discuss.streamlit.io/t/typeerror-descriptors-cannot-not-be-created-directly/25639/12 adding `protobuf~=3.19` resolves this.