### PR TITLE
Add time profiling for CI

### DIFF
--- a/now/cloud_manager.py
+++ b/now/cloud_manager.py
@@ -12,7 +12,7 @@ from now.constants import JC_SECRET
 from now.dataclasses import UserInput
 from now.deployment.deployment import cmd
 from now.dialog import maybe_prompt_user
-from now.log.log import yaspin_extended
+from now.log.log import time_profiler, yaspin_extended
 from now.utils import sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()
@@ -109,6 +109,7 @@ def check_wolf_deployment(**kwargs):
             exit(0)
 
 
+@time_profiler
 def setup_cluster(
     user_input: UserInput,
     kubectl_path='kubectl',

--- a/now/cloud_manager.py
+++ b/now/cloud_manager.py
@@ -12,7 +12,7 @@ from now.constants import JC_SECRET
 from now.dataclasses import UserInput
 from now.deployment.deployment import cmd
 from now.dialog import maybe_prompt_user
-from now.log.log import time_profiler, yaspin_extended
+from now.log import time_profiler, yaspin_extended
 from now.utils import sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()

--- a/now/data_loading/data_loading.py
+++ b/now/data_loading/data_loading.py
@@ -17,7 +17,7 @@ from now.constants import (
 )
 from now.data_loading.convert_datasets_to_jpeg import to_thumbnail_jpg
 from now.dataclasses import UserInput
-from now.log.log import yaspin_extended
+from now.log import yaspin_extended
 from now.utils import download, sigmap
 
 

--- a/now/deployment/flow.py
+++ b/now/deployment/flow.py
@@ -16,7 +16,7 @@ from now.cloud_manager import is_local_cluster
 from now.constants import JC_SECRET
 from now.dataclasses import UserInput
 from now.deployment.deployment import apply_replace, cmd, deploy_wolf
-from now.log.log import time_profiler, yaspin_extended
+from now.log import time_profiler, yaspin_extended
 from now.utils import sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()

--- a/now/deployment/flow.py
+++ b/now/deployment/flow.py
@@ -16,7 +16,7 @@ from now.cloud_manager import is_local_cluster
 from now.constants import JC_SECRET
 from now.dataclasses import UserInput
 from now.deployment.deployment import apply_replace, cmd, deploy_wolf
-from now.log.log import yaspin_extended
+from now.log.log import time_profiler, yaspin_extended
 from now.utils import sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()
@@ -106,6 +106,7 @@ def deploy_k8s(f, ns, tmpdir, kubectl_path):
     return gateway_host, gateway_port, gateway_host_internal, gateway_port_internal
 
 
+@time_profiler
 def deploy_flow(
     user_input: UserInput,
     app_instance: JinaNOWApp,

--- a/now/dialog.py
+++ b/now/dialog.py
@@ -20,7 +20,7 @@ from now.apps.base.app import JinaNOWApp
 from now.constants import AVAILABLE_DATASET, Apps, DatasetTypes
 from now.dataclasses import UserInput
 from now.deployment.deployment import cmd
-from now.log.log import yaspin_extended
+from now.log import yaspin_extended
 from now.thirdparty.PyInquirer import Separator
 from now.thirdparty.PyInquirer.prompt import prompt
 from now.utils import sigmap, to_camel_case

--- a/now/finetuning/run_finetuning.py
+++ b/now/finetuning/run_finetuning.py
@@ -16,7 +16,6 @@ from finetuner.tuner.callback import (
 )
 from finetuner.tuner.pytorch.losses import TripletLoss
 from finetuner.tuner.pytorch.miner import TripletEasyHardMiner
-from yaspin import yaspin
 
 from now.constants import Apps
 from now.dataclasses import UserInput
@@ -26,6 +25,7 @@ from now.finetuning.settings import FinetuneSettings
 from now.hub.head_encoder.head_encoder import LinearHead, get_bi_modal_embedding
 from now.hub.hub import push_to_hub
 from now.improvements.improvements import show_improvement
+from now.log.log import yaspin_extended
 from now.utils import sigmap
 
 _BASE_SAVE_DIR = 'now/hub/head_encoder'
@@ -148,7 +148,7 @@ def _finetune_dir() -> str:
 def _maybe_add_embeddings(
     user_input: UserInput, dataset: DocumentArray, kubectl_path: str
 ):
-    with yaspin(
+    with yaspin_extended(
         sigmap=sigmap, text="Check if embeddings already exist", color="green"
     ) as spinner:
         if all([d.embedding is not None for d in dataset]):
@@ -188,7 +188,9 @@ def _show_finetune_improvements(
     val_query_image = deepcopy(
         val_index_image.sample(k=finetune_settings.num_val_queries, seed=42)
     )
-    with yaspin(sigmap=sigmap, text="Create overview", color="green") as spinner:
+    with yaspin_extended(
+        sigmap=sigmap, text="Create overview", color="green"
+    ) as spinner:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")

--- a/now/finetuning/run_finetuning.py
+++ b/now/finetuning/run_finetuning.py
@@ -25,7 +25,7 @@ from now.finetuning.settings import FinetuneSettings
 from now.hub.head_encoder.head_encoder import LinearHead, get_bi_modal_embedding
 from now.hub.hub import push_to_hub
 from now.improvements.improvements import show_improvement
-from now.log.log import yaspin_extended
+from now.log import yaspin_extended
 from now.utils import sigmap
 
 _BASE_SAVE_DIR = 'now/hub/head_encoder'

--- a/now/hub/hub.py
+++ b/now/hub/hub.py
@@ -3,7 +3,7 @@ import pathlib
 import subprocess
 from datetime import datetime
 
-from now.log.log import yaspin_extended
+from now.log import yaspin_extended
 from now.utils import copytree, sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()

--- a/now/log/__init__.py
+++ b/now/log/__init__.py
@@ -1,0 +1,1 @@
+from .log import time_profiler, yaspin_extended

--- a/now/log/log.py
+++ b/now/log/log.py
@@ -1,4 +1,8 @@
+import datetime
 import os
+import sys
+import time
+from functools import wraps
 
 from yaspin.core import Yaspin
 
@@ -13,6 +17,7 @@ class YaspinExtended(Yaspin):
 
     def __enter__(self):
         if 'NOW_CI_RUN' in os.environ:
+            self.now_ci_run_t0 = time.time()
             return self
         else:
             return super().__enter__()
@@ -20,3 +25,45 @@ class YaspinExtended(Yaspin):
     def __exit__(self, exc_type, exc_val, traceback):
         if 'NOW_CI_RUN' not in os.environ:
             return super().__exit__(exc_type, exc_val, traceback)
+        else:
+            # inspired from Yaspin._freeze and Yaspin._compose_out
+            elapsed_time = time.time() - self.now_ci_run_t0
+            sec, fsec = divmod(round(100 * elapsed_time), 100)
+            text = self._text + " ({}.{:02.0f})\n".format(
+                datetime.timedelta(seconds=sec), fsec
+            )
+            with self._stdout_lock:
+                sys.stdout.write(text)
+
+    def ok(self, text="OK"):
+        if 'NOW_CI_RUN' not in os.environ:
+            return super().ok(text=text)
+        else:
+            if text:
+                self._text = text + ' ' + self._text
+
+    def fail(self, text="FAIL"):
+        if 'NOW_CI_RUN' not in os.environ:
+            return super().fail(text=text)
+        else:
+            if text:
+                self._text = text + ' ' + self._text
+
+
+def time_profiler(fun):
+    @wraps(fun)
+    def profiled_fun(*args, **kwargs):
+        if 'NOW_CI_RUN' in os.environ:
+            t0 = time.time()
+        result = fun(*args, **kwargs)
+        if 'NOW_CI_RUN' in os.environ:
+            elapsed_time = time.time() - t0
+            sec, fsec = divmod(round(100 * elapsed_time), 100)
+            print(
+                "Time to execute {}.{}: ({}.{:02.0f})".format(
+                    fun.__module__, fun.__name__, datetime.timedelta(seconds=sec), fsec
+                )
+            )
+        return result
+
+    return profiled_fun

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -9,7 +9,7 @@ from now.cloud_manager import setup_cluster
 from now.constants import JC_SECRET, SURVEY_LINK
 from now.deployment.deployment import cmd, status_wolf, terminate_wolf
 from now.dialog import _get_context_names, configure_user_input, maybe_prompt_user
-from now.log.log import yaspin_extended
+from now.log import yaspin_extended
 from now.system_information import get_system_state
 from now.utils import sigmap
 

--- a/now/run_backend.py
+++ b/now/run_backend.py
@@ -13,6 +13,7 @@ from now.deployment.flow import deploy_flow
 from now.finetuning.embeddings import get_encoder_config
 from now.finetuning.run_finetuning import finetune_now
 from now.finetuning.settings import FinetuneSettings, parse_finetune_settings
+from now.log.log import time_profiler
 
 cur_dir = pathlib.Path(__file__).parent.resolve()
 
@@ -46,6 +47,7 @@ def finetune_flow_setup(
     return env
 
 
+@time_profiler
 def run(app_instance: JinaNOWApp, user_input: UserInput, kubectl_path: str):
     """
     TODO: Write docs

--- a/now/run_backend.py
+++ b/now/run_backend.py
@@ -13,7 +13,7 @@ from now.deployment.flow import deploy_flow
 from now.finetuning.embeddings import get_encoder_config
 from now.finetuning.run_finetuning import finetune_now
 from now.finetuning.settings import FinetuneSettings, parse_finetune_settings
-from now.log.log import time_profiler
+from now.log import time_profiler
 
 cur_dir = pathlib.Path(__file__).parent.resolve()
 

--- a/now/run_bff_playground.py
+++ b/now/run_bff_playground.py
@@ -5,12 +5,13 @@ from time import sleep
 import requests
 
 from now.deployment.deployment import apply_replace, cmd
-from now.log.log import yaspin_extended
+from now.log.log import time_profiler, yaspin_extended
 from now.utils import sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()
 
 
+@time_profiler
 def run(
     output_modality,
     dataset,

--- a/now/run_bff_playground.py
+++ b/now/run_bff_playground.py
@@ -5,7 +5,7 @@ from time import sleep
 import requests
 
 from now.deployment.deployment import apply_replace, cmd
-from now.log.log import time_profiler, yaspin_extended
+from now.log import time_profiler, yaspin_extended
 from now.utils import sigmap
 
 cur_dir = pathlib.Path(__file__).parent.resolve()


### PR DESCRIPTION
This PR closes #230 by adding

- a decorator (`now.log.log.time_profiler`) to profile functions runtime
- an extension of `extended_yaspin` to show time needed for that spinner to finish
- decoration of known time-consuming functions with above decorator
- all time logging is in the format `HH:MM:SS.FSECFSEC`

With above decorator one can decorator any new function. As we typically use a spinner for time-consuming code block, the extension of `extended_yaspin` will log that time consumption.

An example output of the CI for `best-artworks` deployed `local`:

<img width="1387" alt="Screen Shot 2022-05-31 at 7 48 27 PM" src="https://user-images.githubusercontent.com/47435119/171252131-d0643d63-f6d2-4f42-b8d4-d4902caf8a47.png">
 

Output options of decorator are (let me know if you have other suggestions than the current one)
- `Time to execute now.cloud_manager.setup_cluster: (0:00:18.21)` (current one)
- `[now.cloud_manager.setup_cluster: 0:00:18.21]` (alternative)