### PR TITLE
fix: now stop delete namespace

### DIFF
--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -40,22 +40,22 @@ def stop_now(contexts, active_context, **kwargs):
         ]
         cluster = maybe_prompt_user(questions, 'cluster', **kwargs)
     if cluster == 'kind-jina-now':
-        only_delete_namespace = maybe_prompt_user(
+        delete_cluster = maybe_prompt_user(
             [
                 {
                     'type': 'list',
-                    'name': 'delete-ns',
-                    'message': 'Do you want to delete the namespace only and keep the cluster?',
+                    'name': 'delete-cluster',
+                    'message': 'Do you want to delete the entire cluster or just the namespace?',
                     'choices': [
-                        {'name': '⛔ no', 'value': False},
-                        {'name': '✅ yes', 'value': True},
+                        {'name': '⛔ no, keep the cluster', 'value': False},
+                        {'name': '✅ yes, delete everything', 'value': True},
                     ],
                 }
             ],
-            attribute='delete-ns',
+            attribute='delete-cluster',
             **kwargs,
         )
-        if not only_delete_namespace:
+        if delete_cluster:
             with yaspin_extended(
                 sigmap=sigmap, text=f"Remove local cluster {cluster}", color="green"
             ) as spinner:

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -81,6 +81,13 @@ def stop_now(contexts, active_context, **kwargs):
             terminate_wolf(flow_id)
         os.remove(user(JC_SECRET))
         cowsay.cow(f'remote Flow `{cluster}` removed')
+    else:
+        with yaspin_extended(
+            sigmap=sigmap, text=f"Remove jina NOW from {cluster}", color="green"
+        ) as spinner:
+            cmd(f'{kwargs["kubectl_path"]} delete ns nowapi')
+            spinner.ok('💀')
+        cowsay.cow(f'nowapi namespace removed from {cluster}')
 
 
 def get_task(kwargs):

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -39,6 +39,7 @@ def cleanup(deployment_type, dataset):
             'deployment_type': deployment_type,
             'now': 'stop',
             'cluster': 'kind-jina-now',
+            'delete-cluster': True,
         }
         kwargs = Namespace(**kwargs)
         cli(args=kwargs)


### PR DESCRIPTION
Currently, it was not possible for me to only delete the namespace when running `jina-now stop`.

### Current Code
```
    if len(choices) == 0:
        ...
    else:
        questions = [
            {
                'type': 'list',
                'name': 'cluster',
                'message': 'Which cluster do you want to delete?',
                'choices': choices,
            }
        ]
        cluster = maybe_prompt_user(questions, 'cluster', **kwargs)
    if cluster == 'kind-jina-now':
        ...
    elif 'wolf.jina.ai' in cluster:
        ...
    else:
        with yaspin_extended(
            sigmap=sigmap, text=f"Remove jina NOW from {cluster}", color="green"
        ) as spinner:
            cmd(f'{kwargs["kubectl_path"]} delete ns nowapi')
            spinner.ok('💀')
        cowsay.cow(f'nowapi namespace removed from {cluster}')
```
The namespace deletion branch is in the last `else` which can only reached when the users selects a choice other than 
a wolf cluster or the standard `kind-jina-now` cluster. But the options don't offer any other choice, therefore the last `else` cannot be reached.

In this PR remove the last `else` and add a question in the `kind-jina-now` case that asks whether the user only wants to delete the namespace or the entire cluster.