### PR TITLE
feat: skip finetuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,20 @@ Example of the swagger ui.
 
 <img width="350" alt="Screenshot 2022-05-26 at 16 36 06" src="https://user-images.githubusercontent.com/11627845/170511580-230d1e41-5e14-4623-adb6-3d4b2d400dc9.png">
 
+### Finetuning
+If you want to finetune on your own labels, you need to create a DocumentArray for your dataset and put the class labels into the `document.tags` using `finetuner-label` as key.
+Here is an example:
+```python
+from docarray import DocumentArray, Document
 
+da = DocumentArray([
+    Document(text='first doc', tags={'finetuner-label': 'class1'}),
+    Document(text='second doc', tags={'finetuner-label': 'class1'}),
+    Document(text='third doc', tags={'finetuner-label': 'class2'}),
+    ...
+])
+```
+In case you want to skip finetuning, you can use the flag `--skip-finetuning true`.
   
 ### Use CLI Parameters
 Instead of answering the questions manually, you can also provide command-line arguments when starting Jina NOW like shown here.

--- a/now/cli/parser.py
+++ b/now/cli/parser.py
@@ -85,6 +85,13 @@ def set_default_start_args(parser):
         type=str,
     )
 
+    parser.add_argument(
+        '--skip-finetuning',
+        help='If set true, finetuning will be skipped even if finetuner_label is set.',
+        type=bool,
+        default=False,
+    )
+
 
 def set_start_parser(sp):
     """Add the arguments for the jina now to the parser

--- a/now/dataclasses.py
+++ b/now/dataclasses.py
@@ -25,3 +25,4 @@ class UserInput:
     cluster: Optional[str] = None
     create_new_cluster: Optional[bool] = False
     deployment_type: Optional[str] = None
+    skip_finetuning: bool = False

--- a/now/dialog.py
+++ b/now/dialog.py
@@ -47,10 +47,15 @@ def _construct_app(app) -> JinaNOWApp:
     )()
 
 
+def _configure_additional_cli_params(user_input, **kwargs):
+    user_input.skip_finetuning = kwargs['skip_finetuning']
+
+
 def configure_user_input(**kwargs) -> [JinaNOWApp, UserInput]:
     print_headline()
 
     user_input = UserInput()
+    _configure_additional_cli_params(user_input, **kwargs)
     _configure_app(user_input, **kwargs)
     app_instance = _construct_app(user_input.app)
     app_instance.check_requirements()

--- a/now/finetuning/settings.py
+++ b/now/finetuning/settings.py
@@ -70,6 +70,9 @@ def _get_pre_trained_embedding_size(user_input: UserInput) -> int:
 def _is_finetuning(
     user_input: UserInput, dataset: DocumentArray, finetune_datasets: Tuple
 ) -> bool:
+    if user_input.skip_finetuning:
+        print('Skip finetuning since --skip-finetuning flag is set.')
+        return False
     if user_input.data in finetune_datasets:
         return True
 


### PR DESCRIPTION
As requested by @ZiniuYu, finetuning can now be skipped using `--skip-finetuning true`.
<img width="614" alt="image" src="https://user-images.githubusercontent.com/11627845/174772115-a230e5a6-d6c8-480d-9e38-3e5ffce3e6fc.png">
