### PR TITLE
feat: use msmarco-distilbert-base-v3 for text-to-text search

### DIFF
--- a/now/apps/text_to_text/app.py
+++ b/now/apps/text_to_text/app.py
@@ -45,9 +45,7 @@ class TextToText(JinaNOWApp):
         self, da: DocumentArray, user_config: UserInput, kubectl_path: str
     ) -> Dict:
         quality_pretrained_model_map = {
-            # Qualities.MEDIUM: 'paraphrase-MiniLM-L3-v2',
-            # Qualities.GOOD: 'sentence-transformers/all-MiniLM-L6-v2',
-            Qualities.MEDIUM: 'sentence-transformers/all-MiniLM-L6-v2',
+            Qualities.MEDIUM: 'sentence-transformers/msmarco-distilbert-base-v3',
         }
         return finetune_flow_setup(
             self,


### PR DESCRIPTION
Incorporates preliminary strong insights from #266 to use `msmarco-distilbert-base-v3` instead of `all-MiniLM-L6-v2` as the pre-training regiment of the former (training retrieval tasks on bing search queries, incl. keyword, phrases and questions) is better suited for our purposes.