### PR TITLE
feat: enable monitoring for flow-clip

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -40,11 +40,11 @@ jobs:
       - name: Test
         id: test
         run: pytest --suppress-no-test-exit-code -v -s -m "not gpu" --splits 6 --group ${{ matrix.group }} tests/
-        timeout-minutes: 25
+        timeout-minutes: 30
       - name: Setup tmate session for debugging
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 120
+        timeout-minutes: 60
 
   prerelease:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,11 +184,11 @@ jobs:
         run: |
           pytest --suppress-no-test-exit-code --cov=now \
           -v -s -m "not gpu" --splits 6 --group ${{ matrix.group }} tests/
-        timeout-minutes: 25
+        timeout-minutes: 30
       - name: Setup tmate session for debugging
         if: ${{ failure() || (github.event_name == 'workflow_dispatch' && github.event.inputs.debug_enabled) }}
         uses: mxschmitt/action-tmate@v3
-        timeout-minutes: 120
+        timeout-minutes: 60
       - name: Upload coverage
         uses: actions/upload-artifact@v2
         with:

--- a/now_common/flow/flow-clip.yml
+++ b/now_common/flow/flow-clip.yml
@@ -1,6 +1,7 @@
 jtype: Flow
 with:
   name: nowapi
+  monitoring: true
   port_expose: 8080
   prefetch: 10
   cors: True


### PR DESCRIPTION
## Context ##

Team Wolf has developed a new feature that allows monitoring function for JCloud deployed Flow. This can be enrolled by setting `monitoring: true` in Flow YAML. Talked to @makram93, we decided to enable one and test it out.