### PR TITLE
Update JCloud and use latest jina auth

### DIFF
--- a/now/utils.py
+++ b/now/utils.py
@@ -16,9 +16,6 @@ from docarray import Document
 from PIL import Image, ImageDraw, ImageFont
 from rich.console import Console
 
-from now.deployment.deployment import cmd
-from now.log import yaspin_extended
-
 colors = [
     "navy",
     "turquoise",
@@ -351,27 +348,17 @@ def write_env_file(env_file, config):
         fp.write(config_string)
 
 
+@hubble.login_required
+def jina_auth_login():
+    pass
+
+
 def _get_info_hubble(user_input):
-    login = False
-    if not os.path.exists(user('~/.jina/config.json')):
-        login = True
-    if not login:
-        with open(user('~/.jina/config.json')) as fp:
-            config_val = json.load(fp)
-            user_token = config_val['auth_token']
-        client = hubble.Client(token=user_token, max_retries=None, jsonify=True)
-        response = client.get_user_info()
-        if response['code'] == 200:
-            user_input.admin_emails = [response['data']['_id']]
-            user_input.jwt = {'user': response['data'], 'token': user_token}
-            return response['data'], user_token
-        else:
-            login = True
-    if login:
-        with yaspin_extended(
-            sigmap=sigmap, text='Log in to JCloud', color='green'
-        ) as spinner:
-            # hubble.login()
-            cmd('jc login')
-        spinner.ok('🛠️')
-        _get_info_hubble(user_input)
+    with open(user('~/.jina/config.json')) as fp:
+        config_val = json.load(fp)
+        user_token = config_val['auth_token']
+    client = hubble.Client(token=user_token, max_retries=None, jsonify=True)
+    response = client.get_user_info()
+    user_input.admin_emails = [response['data']['_id']]
+    user_input.jwt = {'user': response['data'], 'token': user_token}
+    return response['data'], user_token

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ docker==5.0.3
 requests==2.27.1
 pydub==0.25.1
 nltk==3.7
-jcloud==0.0.32
+jcloud==0.0.34
 python-dotenv
 boto3
 jina-hubble-sdk==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ docker==5.0.3
 requests==2.27.1
 pydub==0.25.1
 nltk==3.7
-jcloud==0.0.34
+jcloud==0.0.35
 python-dotenv
 boto3
 jina-hubble-sdk==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,4 @@ nltk==3.7
 jcloud==0.0.32
 python-dotenv
 boto3
-jina-hubble-sdk
+jina-hubble-sdk==0.13.0


### PR DESCRIPTION
In this PR we update the requirements and make use of the latest version of `jina-hubble-sdk` which is the central library for auth across Jina ecosystem.