### PR TITLE
feat: trigger dispatch workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,7 @@ jobs:
           tags: jinaai/now-playground:${{ env.BFF_PLAYGROUND_TAG }}
 
   core-test:
+    if: !startsWith(github.event.head_commit.message, 'chore')
     runs-on: ubuntu-latest
     needs: [update-preprocessor-if-required, update-bff-playground-if-required]
     strategy:

--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -7,37 +7,35 @@ on:
         description: 'Short reason for this manual release'
         required: true
 
-  pull_request:
-
 jobs:
-#  regular-release:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#        with:
-#          token: ${{ secrets.JINA_DEV_BOT }}
-#          fetch-depth: 100  # means max contribute history is limited to 100 lines
-##          submodules: true
-#      - uses: actions/setup-python@v2
-#        with:
-#          python-version: 3.7
-#      - run: |
-#          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-#          npm install git-release-notes
-#          pip install twine wheel
-#          ./scripts/release.sh final "${{ github.event.inputs.release_reason }}" "${{github.actor}}"
-#        env:
-#          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-#          JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}
-#      - if: failure()
-#        run: echo "nothing to release"
-#      - name: bumping master version
-#        uses: ad-m/github-push-action@v0.6.0
-#        with:
-#          github_token: ${{ secrets.JINA_DEV_BOT }}
-#          tags: true
-#          branch: main
+  regular-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.JINA_DEV_BOT }}
+          fetch-depth: 100  # means max contribute history is limited to 100 lines
+#          submodules: true
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          npm install git-release-notes
+          pip install twine wheel
+          ./scripts/release.sh final "${{ github.event.inputs.release_reason }}" "${{github.actor}}"
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}
+      - if: failure()
+        run: echo "nothing to release"
+      - name: bumping master version
+        uses: ad-m/github-push-action@v0.6.0
+        with:
+          github_token: ${{ secrets.JINA_DEV_BOT }}
+          tags: true
+          branch: main
 
 
   trigger-now-private:

--- a/.github/workflows/force-release.yml
+++ b/.github/workflows/force-release.yml
@@ -7,32 +7,46 @@ on:
         description: 'Short reason for this manual release'
         required: true
 
+  pull_request:
+
 jobs:
-  regular-release:
+#  regular-release:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#        with:
+#          token: ${{ secrets.JINA_DEV_BOT }}
+#          fetch-depth: 100  # means max contribute history is limited to 100 lines
+##          submodules: true
+#      - uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.7
+#      - run: |
+#          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+#          npm install git-release-notes
+#          pip install twine wheel
+#          ./scripts/release.sh final "${{ github.event.inputs.release_reason }}" "${{github.actor}}"
+#        env:
+#          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+#          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+#          JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}
+#      - if: failure()
+#        run: echo "nothing to release"
+#      - name: bumping master version
+#        uses: ad-m/github-push-action@v0.6.0
+#        with:
+#          github_token: ${{ secrets.JINA_DEV_BOT }}
+#          tags: true
+#          branch: main
+
+
+  trigger-now-private:
+    name: Dispatch to now.private to package now_api
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Emit repository_dispatch to now.private
+        uses: mvasigh/dispatch-action@main
         with:
-          token: ${{ secrets.JINA_DEV_BOT }}
-          fetch-depth: 100  # means max contribute history is limited to 100 lines
-#          submodules: true
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - run: |
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          npm install git-release-notes
-          pip install twine wheel
-          ./scripts/release.sh final "${{ github.event.inputs.release_reason }}" "${{github.actor}}"
-        env:
-          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          JINA_SLACK_WEBHOOK: ${{ secrets.JINA_SLACK_WEBHOOK }}
-      - if: failure()
-        run: echo "nothing to release"
-      - name: bumping master version
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.JINA_DEV_BOT }}
-          tags: true
-          branch: main
+          repo: now.private
+          owner: jinaai
+          event_type: update_api


### PR DESCRIPTION
This PR adds dispatch workflows to trigger the CD workflow of now.private whenever a new Jina NOW version is released. This is done to automate the process of keeping the `now_api` up to date. 