### PR TITLE
test: timeout

### DIFF
--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -107,6 +107,7 @@ def test_token_exists():
     ],
 )
 @pytest.mark.parametrize('quality', ['medium'])
+@pytest.mark.timeout(60 * 15)
 def test_backend_demo_data(
     app: str,
     dataset: str,


### PR DESCRIPTION
Today, I had to delete a lot of ci flows again. I think the reason is that sometimes the tests are timing out due to errors in some executors. In that case, the flow is not deleted. In this pr, we set a timeout for the test itself to make sure the cleanup fixture is triggered.
<img width="680" alt="image" src="https://user-images.githubusercontent.com/11627845/188018892-1f2f4f30-4aa7-4394-a7d6-f3c37f965efe.png">
