### PR TITLE
fix: add api keys

### DIFF
--- a/now/admin/update_api_keys.py
+++ b/now/admin/update_api_keys.py
@@ -24,8 +24,9 @@ def update_api_keys(deployment_type, api_keys):
 
 if __name__ == '__main__':
     api_key = str(uuid.uuid4())
-    update_api_keys(
-        deployment_type='remote',
-        api_keys=[api_key],
-    )
-    print(api_key)
+    for i in range(100):  # increase the probability that all replicas get the new key
+        update_api_keys(
+            deployment_type='remote',
+            api_keys=[api_key],
+        )
+        print(api_key)


### PR DESCRIPTION
Since we are using replicas, the propagation of the API key can not be guaranteed. We increase the likelihood that all replicas will get a key by sending more requests.
Assume, we have 10 replicas and 100 requests of type `add_api_key`.
We assume that the probability of what replica is used is evenly distributed.
It means that the likelihood that a replica has an api_key is:
`1-(9/10)^100` ~ 1
