### PR TITLE
fix: playground url inside try catch

### DIFF
--- a/deployment/playground/playground.py
+++ b/deployment/playground/playground.py
@@ -261,8 +261,8 @@ def load_example_queries(data, output_modality):
                 output_modality_dir = 'text'
                 data_dir = root_data_dir + output_modality_dir + '/'
                 da_txt = load_data(data_dir + data + f'.txt10-{docarray_version}.bin')
-        except HTTPError:
-            pass
+        except HTTPError as exc:
+            print('Could not load samples for the demo dataset', exc)
     return da_img, da_txt
 
 

--- a/deployment/playground/playground.py
+++ b/deployment/playground/playground.py
@@ -3,6 +3,7 @@ import io
 import json
 import os
 from copy import deepcopy
+from urllib.error import HTTPError
 from urllib.parse import quote, unquote
 from urllib.request import urlopen
 
@@ -111,13 +112,9 @@ def deploy_streamlit():
     if redirect_to and st.session_state.login:
         nav_to(redirect_to)
     else:
-        da_img = None
-        da_txt = None
         media_type = 'Text'
 
-        da_img, da_txt = load_example_queries(
-            params.data, params.output_modality, da_img, da_txt
-        )
+        da_img, da_txt = load_example_queries(params.data, params.output_modality)
 
         if params.output_modality == 'text':
             # censor words in text incl. in custom data
@@ -248,19 +245,24 @@ def _do_logout():
     cookie_manager.delete(cookie=JWT_COOKIE, key=JWT_COOKIE)
 
 
-def load_example_queries(DATA, OUTPUT_MODALITY, da_img, da_txt):
-    if DATA in ds_set:
-        if OUTPUT_MODALITY == 'image' or OUTPUT_MODALITY == 'video':
-            output_modality_dir = 'jpeg'
-            data_dir = root_data_dir + output_modality_dir + '/'
-            da_img, da_txt = load_data(
-                data_dir + DATA + f'.img10-{docarray_version}.bin'
-            ), load_data(data_dir + DATA + f'.txt10-{docarray_version}.bin')
-        elif OUTPUT_MODALITY == 'text':
-            # for now deactivated sample images for text
-            output_modality_dir = 'text'
-            data_dir = root_data_dir + output_modality_dir + '/'
-            da_txt = load_data(data_dir + DATA + f'.txt10-{docarray_version}.bin')
+def load_example_queries(data, output_modality):
+    da_img = None
+    da_txt = None
+    if data in ds_set:
+        try:
+            if output_modality == 'image' or output_modality == 'video':
+                output_modality_dir = 'jpeg'
+                data_dir = root_data_dir + output_modality_dir + '/'
+                da_img, da_txt = load_data(
+                    data_dir + data + f'.img10-{docarray_version}.bin'
+                ), load_data(data_dir + data + f'.txt10-{docarray_version}.bin')
+            elif output_modality == 'text':
+                # for now deactivated sample images for text
+                output_modality_dir = 'text'
+                data_dir = root_data_dir + output_modality_dir + '/'
+                da_txt = load_data(data_dir + data + f'.txt10-{docarray_version}.bin')
+        except HTTPError:
+            pass
     return da_img, da_txt
 
 
@@ -599,15 +601,7 @@ def clear_text():
 
 def load_data(data_path: str) -> DocumentArray:
     if data_path.startswith('http'):
-        try:
-            # TODO try except is used as workaround
-            # in case load_data is called two times from two playgrounds it can happen that
-            # one of the calls created the directory right after checking that it does not exist
-            # this caused errors. Now the error will be ignored.
-            # Can not use `exist=True` because it is not available in py3.7
-            os.makedirs('data/tmp')
-        except:
-            pass
+        os.makedirs('data/tmp', exist_ok=True)
         url = data_path
         data_path = (
             f"data/tmp/{base64.b64encode(bytes(url, 'utf-8')).decode('utf-8')}.bin"

--- a/now/constants.py
+++ b/now/constants.py
@@ -5,7 +5,7 @@ from now.utils import BetterEnum
 # DEMO_DATASET_DOCARRAY_VERSION = docarray_version
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
-DOCKER_BFF_PLAYGROUND_TAG = '0.0.126-revert-playground-1'
+DOCKER_BFF_PLAYGROUND_TAG = '0.0.126-playground-demo-url-1'
 NOW_PREPROCESSOR_VERSION = '0.0.85-finetune3'
 NOW_AUTH_EXECUTOR_VERSION = '0.0.5-auth-exec-4'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.4-revert-playground-1'

--- a/now/constants.py
+++ b/now/constants.py
@@ -5,7 +5,7 @@ from now.utils import BetterEnum
 # DEMO_DATASET_DOCARRAY_VERSION = docarray_version
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
-DOCKER_BFF_PLAYGROUND_TAG = '0.0.126-playground-demo-url-1'
+DOCKER_BFF_PLAYGROUND_TAG = '0.0.126-playground-demo-url-2'
 NOW_PREPROCESSOR_VERSION = '0.0.85-finetune3'
 NOW_AUTH_EXECUTOR_VERSION = '0.0.5-auth-exec-4'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.4-revert-playground-1'


### PR DESCRIPTION
When loading samples, if the link is not correct then it will throw HTTP error. Instead of that, catch the error silently and do not show the samples.