### PR TITLE
fix: update list endpoint and test cases

### DIFF
--- a/now/constants.py
+++ b/now/constants.py
@@ -7,7 +7,7 @@ DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
 NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
-NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-1'
+NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-2'
 
 
 class Modalities(BetterEnum):

--- a/now/constants.py
+++ b/now/constants.py
@@ -7,7 +7,7 @@ DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
 NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
-NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-2'
+NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-3'
 
 
 class Modalities(BetterEnum):

--- a/now/constants.py
+++ b/now/constants.py
@@ -7,7 +7,7 @@ DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
 NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
-NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-3'
+NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-4'
 
 
 class Modalities(BetterEnum):

--- a/now/constants.py
+++ b/now/constants.py
@@ -7,7 +7,7 @@ DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
 NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
-NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-secure-playground-3'
+NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-1'
 
 
 class Modalities(BetterEnum):

--- a/now_executors/NOWAnnLiteIndexer/executor.py
+++ b/now_executors/NOWAnnLiteIndexer/executor.py
@@ -232,8 +232,8 @@ class NOWAnnLiteIndexer(Executor):
         )
         # add removal of duplicates
         traversal_paths = parameters.get('traversal_paths', self.search_traversal_paths)
-        docs = DocumentArray()
         if traversal_paths == '@c':
+            docs = DocumentArray()
             chunks_size = (
                 int(parameters.get('chunks_size'))
                 if parameters.get('chunks_size')
@@ -247,6 +247,8 @@ class NOWAnnLiteIndexer(Executor):
                     continue
                 parent_ids.add(d.parent_id)
                 docs.append(d)
+        else:
+            docs = self.da[offset : offset + limit]
         return docs
 
     @secure_request(on='/search', level=SecurityLevel.USER)

--- a/now_executors/NOWAnnLiteIndexer/executor.py
+++ b/now_executors/NOWAnnLiteIndexer/executor.py
@@ -222,23 +222,13 @@ class NOWAnnLiteIndexer(Executor):
         - offset (int): number of documents to skip
         - limit (int): number of retrieved documents
         """
-        limit = (
-            int(parameters.get('limit'))
-            if parameters.get('limit') is not None
-            else maxsize
-        )
-        offset = (
-            int(parameters.get('offset')) if parameters.get('offset') is not None else 0
-        )
+        limit = int(parameters.get('limit', maxsize))
+        offset = int(parameters.get('offset', 0))
         # add removal of duplicates
         traversal_paths = parameters.get('traversal_paths', self.search_traversal_paths)
         if traversal_paths == '@c':
             docs = DocumentArray()
-            chunks_size = (
-                int(parameters.get('chunks_size'))
-                if parameters.get('chunks_size')
-                else 3
-            )
+            chunks_size = int(parameters.get('chunks_size', 3))
             parent_ids = set()
             for d in self.da[offset * chunks_size :]:
                 if len(parent_ids) == limit:

--- a/tests/now_executors/NOWAnnLiteIndexer/test_executor.py
+++ b/tests/now_executors/NOWAnnLiteIndexer/test_executor.py
@@ -65,9 +65,9 @@ def test_index(tmpdir):
 
 
 @pytest.mark.parametrize(
-    'offset, limit', [(0, 0)]  # , (10, 0), (0, 10), (10, 10), (None, None)]
+    'offset, limit', [(0, 0), (10, 0), (0, 10), (10, 10), (None, None)]
 )
-@pytest.mark.parametrize('has_chunk', [True])
+@pytest.mark.parametrize('has_chunk', [True, False])
 def test_list(tmpdir, offset, limit, has_chunk):
     """Test list returns all indexed docs"""
     metas = {'workspace': str(tmpdir)}
@@ -96,7 +96,10 @@ def test_list(tmpdir, offset, limit, has_chunk):
         f.post(on='/index', inputs=docs, parameters=parameters)
         list_res = f.post(on='/list', parameters=parameters, return_results=True)
         print(limit)
-        l = N if limit is None else limit
+        if offset is None:
+            l = N
+        else:
+            l = max(limit - offset, 0)
         assert len(list_res) == l
         if l > 0:
             if has_chunk:

--- a/tests/now_executors/NOWAnnLiteIndexer/test_executor.py
+++ b/tests/now_executors/NOWAnnLiteIndexer/test_executor.py
@@ -95,7 +95,6 @@ def test_list(tmpdir, offset, limit, has_chunk):
 
         f.post(on='/index', inputs=docs, parameters=parameters)
         list_res = f.post(on='/list', parameters=parameters, return_results=True)
-        print(limit)
         if offset is None:
             l = N
         else:


### PR DESCRIPTION
List endpoint currently returns the flat docs which is wrong when we have chunks of documents. This PR solves it by removing the duplicates and only returning single docs for all chunks of the same parent. 