### PR TITLE
Refactor remove jc secret

### DIFF
--- a/now/admin/update_api_keys.py
+++ b/now/admin/update_api_keys.py
@@ -1,18 +1,21 @@
 import uuid
 
 import requests
-from tests.integration.test_end_to_end import get_default_request_body
+
+from now.admin.utils import get_default_request_body
 
 #  TODO needs to be updated to work on cli / or even putting things like this into a new client package
 
 
-def update_api_keys(deployment_type, api_keys):
+def update_api_keys(deployment_type, api_keys, remote_host=None):
     if deployment_type == 'remote':
         url = f"https://nowrun.jina.ai/api/v1"  # remote
     else:
         url = f'http://localhost:30090/api/v1'  # local
     # url = f'http://localhost:8080/api/v1'  # for local testing
-    request_body = get_default_request_body(deployment_type, secured=True)
+    request_body = get_default_request_body(
+        deployment_type, secured=True, remote_host=remote_host
+    )
     # request_body['host'] = f'grpc://0.0.0.0'  # for local testing
     # request_body['port'] = 9090  # for local testing
     request_body['api_keys'] = api_keys
@@ -28,5 +31,6 @@ if __name__ == '__main__':
         update_api_keys(
             deployment_type='remote',
             api_keys=[api_key],
+            remote_host='grpc://0.0.0.0',
         )
         print(api_key)

--- a/now/admin/update_email.py
+++ b/now/admin/update_email.py
@@ -1,16 +1,19 @@
 import requests
-from tests.integration.test_end_to_end import get_default_request_body
+
+from now.admin.utils import get_default_request_body
 
 #  TODO needs to be updated to work on cli / or even putting things like this into a new client package
 
 
-def update_emails(deployment_type, emails):
+def update_emails(deployment_type, emails, remote_host=None):
     if deployment_type == 'remote':
         url = f"https://nowrun.jina.ai/api/v1"  # remote
     else:
         url = f'http://localhost:30090/api/v1'  # local
     # url = f'http://localhost:8080/api/v1'  # for local testing
-    request_body = get_default_request_body(deployment_type, secured=True)
+    request_body = get_default_request_body(
+        deployment_type, secured=True, remote_host=remote_host
+    )
     # request_body['host'] = f'grpc://0.0.0.0'  # for local testing
     # request_body['port'] = 9090  # for local testing
     request_body['user_emails'] = emails
@@ -25,4 +28,5 @@ if __name__ == '__main__':
     update_emails(
         deployment_type='remote',
         emails=['hoenicke.florian@gmail.com'],
+        remote_host='grpc://0.0.0.0',
     )

--- a/now/admin/utils.py
+++ b/now/admin/utils.py
@@ -9,7 +9,7 @@ def get_default_request_body(deployment_type, secured, remote_host=None):
         request_body['host'] = 'gateway'
         request_body['port'] = 8080
     elif deployment_type == 'remote':
-        if not remote_host:
+        if remote_host:
             request_body['host'] = remote_host
         else:
             raise ValueError('Remote host must be provided for remote deployment')

--- a/now/admin/utils.py
+++ b/now/admin/utils.py
@@ -1,0 +1,20 @@
+import os
+
+import hubble
+
+
+def get_default_request_body(deployment_type, secured, remote_host=None):
+    request_body = {}
+    if deployment_type == 'local':
+        request_body['host'] = 'gateway'
+        request_body['port'] = 8080
+    elif deployment_type == 'remote':
+        if not remote_host:
+            request_body['host'] = remote_host
+        else:
+            raise ValueError('Remote host must be provided for remote deployment')
+    if secured:
+        if 'WOLF_TOKEN' in os.environ:
+            os.environ['JINA_AUTH_TOKEN'] = os.environ['WOLF_TOKEN']
+        request_body['jwt'] = {'token': hubble.get_token()}
+    return request_body

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
-NOW_PREPROCESSOR_VERSION = '0.0.87-refactor-jc-secret-1'
+NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-secure-playground-3'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
-NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
+NOW_PREPROCESSOR_VERSION = '0.0.87-refactor-jc-secret-1'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-secure-playground-3'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -115,6 +115,4 @@ AVAILABLE_DATASET = {
     ],
 }
 
-JC_SECRET = '~/.cache/jina-now/wolf.json'
-
 SURVEY_LINK = 'https://10sw1tcpld4.typeform.com/to/VTAyYRpR?utm_source=cli'

--- a/now/deployment/deployment.py
+++ b/now/deployment/deployment.py
@@ -18,11 +18,13 @@ def status_wolf(flow_id):
     return loop.run_until_complete(CloudFlow(flow_id=flow_id).status)
 
 
-def list_all_wolf(status=None):
+def list_all_wolf(status='READY', namespace='nowapi'):
     loop = asyncio.get_event_loop()
     flows = loop.run_until_complete(CloudFlow().list_all(status=status))
     if flows is None:
-        flows = []
+        return []
+    # filter by namespace - if the namespace is contained in the flow name
+    flows = [flow for flow in flows if namespace in flow['name']]
     return flows
 
 

--- a/now/deployment/flow.py
+++ b/now/deployment/flow.py
@@ -1,8 +1,6 @@
-import json
 import os.path
 import pathlib
 import tempfile
-from os.path import expanduser as user
 from time import sleep
 from typing import Dict
 
@@ -13,7 +11,6 @@ from kubernetes import config
 from yaspin.spinners import Spinners
 
 from now.cloud_manager import is_local_cluster
-from now.constants import JC_SECRET
 from now.deployment.deployment import apply_replace, cmd, deploy_wolf
 from now.log import time_profiler, yaspin_extended
 from now.utils import sigmap, write_env_file
@@ -120,11 +117,6 @@ def deploy_flow(
             flow = deploy_wolf(path=flow_yaml, env_file=env_file, name=ns)
             host = flow.gateway
             client = Client(host=host)
-
-            # Dump the flow ID and gateway to keep track
-            pathlib.Path(user(JC_SECRET)).parent.mkdir(parents=True, exist_ok=True)
-            with open(user(JC_SECRET), 'w') as fp:
-                json.dump({'flow_id': flow.flow_id, 'gateway': host}, fp)
 
             # host & port
             gateway_host = 'remote'

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -84,7 +84,7 @@ def stop_now(app_instance, contexts, active_context, **kwargs):
             cmd(f'{kwargs["kubectl_path"]} delete ns nowapi')
             spinner.ok('💀')
         cowsay.cow(f'nowapi namespace removed from {cluster}')
-    app_instance.cleanup(app_config={})
+    app_instance.cleanup(app_config=dict())
 
 
 def get_task(kwargs):

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -17,7 +17,7 @@ from now.system_information import get_system_state
 from now.utils import maybe_prompt_user, sigmap
 
 
-def stop_now(contexts, active_context, **kwargs):
+def stop_now(app_instance, contexts, active_context, **kwargs):
     choices = _get_context_names(contexts, active_context)
     # Add all remote Flows that exists with the namespace `nowapi`
     alive_flows = list_all_wolf()
@@ -37,8 +37,6 @@ def stop_now(contexts, active_context, **kwargs):
         ]
         cluster = maybe_prompt_user(questions, 'cluster', **kwargs)
     if cluster == 'kind-jina-now':
-        # In case of a local cluster, all resources deployed will have namespace nowapi
-        # and can be deleted by deleting the namespace.
         delete_cluster = maybe_prompt_user(
             [
                 {
@@ -78,8 +76,6 @@ def stop_now(contexts, active_context, **kwargs):
             print(f'❎ Flow not found in JCloud. Likely, it has been deleted already')
         if _result is not None and _result['status'] == 'ALIVE':
             terminate_wolf(flow_id)
-            app_instance = configure_app({'app': flow['envs']['APP']})
-            app_instance.cleanup(app_config={})
         cowsay.cow(f'remote Flow `{cluster}` removed')
     else:
         with yaspin_extended(
@@ -88,6 +84,7 @@ def stop_now(contexts, active_context, **kwargs):
             cmd(f'{kwargs["kubectl_path"]} delete ns nowapi')
             spinner.ok('💀')
         cowsay.cow(f'nowapi namespace removed from {cluster}')
+    app_instance.cleanup(app_config={})
 
 
 def get_task(kwargs):
@@ -165,9 +162,8 @@ def start_now(app_instance, **kwargs):
 def run_k8s(os_type: str = 'linux', arch: str = 'x86_64', **kwargs):
     contexts, active_context = get_system_state(**kwargs)
     task = get_task(kwargs)
-
+    app = configure_app(**kwargs)
     if task == 'start':
-        app = configure_app(**kwargs)
         return start_now(
             app,
             contexts=contexts,
@@ -177,7 +173,7 @@ def run_k8s(os_type: str = 'linux', arch: str = 'x86_64', **kwargs):
             **kwargs,
         )
     elif task == 'stop':
-        return stop_now(contexts, active_context, **kwargs)
+        return stop_now(app, contexts, active_context, **kwargs)
     elif task == 'survey':
         import webbrowser
 

--- a/tests/integration/security/test_api_key.py
+++ b/tests/integration/security/test_api_key.py
@@ -6,9 +6,10 @@ import pytest
 import requests
 from docarray import Document
 from jina import Flow
-from tests.integration.test_end_to_end import assert_search, get_default_request_body
+from tests.integration.test_end_to_end import assert_search
 
 from deployment.bff.app.app import run_server
+from now.admin.utils import get_default_request_body
 from now.constants import EXTERNAL_CLIP_HOST, NOW_ANNLITE_INDEXER_VERSION
 
 API_KEY = 'my_key'
@@ -20,8 +21,8 @@ host = 'grpc://0.0.0.0'
 port = 9090
 
 
-def get_reqest_body():
-    request_body = get_default_request_body('local', True)
+def get_request_body():
+    request_body = get_default_request_body('local', True, None)
     request_body['host'] = 'grpc://0.0.0.0'
     request_body['port'] = 9089
     return request_body
@@ -29,7 +30,7 @@ def get_reqest_body():
 
 def get_flow():
     client = hubble.Client(
-        token=get_reqest_body()['jwt']['token'], max_retries=None, jsonify=True
+        token=get_request_body()['jwt']['token'], max_retries=None, jsonify=True
     )
     admin_email = client.get_user_info()['data'].get('email')
     f = (
@@ -51,7 +52,7 @@ def get_flow():
 def index(f):
     f.index(
         [Document(text='test') for i in range(10)],
-        parameters={'jwt': get_reqest_body()['jwt']},
+        parameters={'jwt': get_request_body()['jwt']},
     )
 
 
@@ -69,7 +70,7 @@ def test_add_key():
         start_bff()
         sleep(10)
 
-        request_body = get_reqest_body()
+        request_body = get_request_body()
         print('# Test adding user email')
         request_body['user_emails'] = ['florian.hoenicke@jina.ai']
         response = requests.post(
@@ -80,7 +81,7 @@ def test_add_key():
 
         print('# test api keys')
         print('# search with invalid api key')
-        request_body = get_reqest_body()
+        request_body = get_request_body()
         request_body['text'] = 'girl on motorbike'
         del request_body['jwt']
         request_body['api_key'] = 'my_key'
@@ -88,7 +89,7 @@ def test_add_key():
         with pytest.raises(Exception):
             assert_search(search_url, request_body)
         print('# add api key')
-        request_body_update_keys = get_reqest_body()
+        request_body_update_keys = get_request_body()
         request_body_update_keys['api_keys'] = ['my_key']
         response = requests.post(
             update_api_keys_url,

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -42,7 +42,7 @@ def cleanup(deployment_type, dataset):
                     return
                 host = flow_details['host']
                 flow_id = host.replace('grpcs://nowapi-', '').replace(
-                    'wolf.jina.ai', ''
+                    '.wolf.jina.ai', ''
                 )
                 terminate_wolf(flow_id)
             else:

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -41,7 +41,9 @@ def cleanup(deployment_type, dataset):
                     print('nothing to clean up')
                     return
                 host = flow_details['host']
-                flow_id = host.replace('grpcs://nowapi-', '').replace('.jina.ai', '')
+                flow_id = host.replace('grpcs://nowapi-', '').replace(
+                    'wolf.jina.ai', ''
+                )
                 terminate_wolf(flow_id)
             else:
                 kwargs = {

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -28,13 +28,14 @@ def test_search_image(resources_folder_path: str):
 
 @pytest.fixture()
 def cleanup(deployment_type, dataset):
+    print('start cleanup')
     start = time.time()
     with tempfile.TemporaryDirectory() as tmpdir:
         yield tmpdir
         try:
             if deployment_type == 'remote':
                 flow_details = {}
-                with open(f'{cleanup}/flow_details.json', 'r') as f:
+                with open(f'{tmpdir}/flow_details.json', 'r') as f:
                     flow_details = json.load(f)
                 if 'host' not in flow_details:
                     print('nothing to clean up')

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -189,9 +189,7 @@ def assert_deployment_queries(
     response,
 ):
     url = f'http://localhost:30090/api/v1'
-    host = None
-    if 'host' in response:
-        host = response['host']
+    host = response.get('host')
     # normal case
     request_body = get_search_request_body(
         app, dataset, deployment_type, kwargs, test_search_image, host


### PR DESCRIPTION
This PR refactors the jc_secret and removes all its occurrences. In the integration test, we still need to keep track of the deployed flow for post-cleanup. We cannot list all flows and deploy them as they may be in use in other parallel tests. 

This PR also solves #542 