### PR TITLE
fix: multiple initialisation prints

### DIFF
--- a/now/cli/__init__.py
+++ b/now/cli/__init__.py
@@ -11,8 +11,6 @@ from now import __version__ as version
 from now.deployment.deployment import cmd
 
 warnings.filterwarnings("ignore")
-if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
-    print(f'Initialising Jina NOW v{version} ...')
 
 cur_dir = pathlib.Path(__file__).parents[1].resolve()
 
@@ -115,8 +113,8 @@ def _get_kubectl_path() -> str:
 
 def cli(args=None):
     """The main entrypoint of the CLI"""
-    # if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
-    #     print(f'Initialising Jina NOW v{version} ...')
+    if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
+        print(f'Initialising Jina NOW v{version} ...')
 
     if not args:
         args = _get_run_args()

--- a/now/cli/__init__.py
+++ b/now/cli/__init__.py
@@ -12,8 +12,6 @@ from now.deployment.deployment import cmd
 
 warnings.filterwarnings("ignore")
 
-if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
-    print(f'Initialising Jina NOW v{version} ...')
 cur_dir = pathlib.Path(__file__).parents[1].resolve()
 
 os.environ['JINA_CHECK_VERSION'] = 'False'
@@ -115,6 +113,9 @@ def _get_kubectl_path() -> str:
 
 def cli(args=None):
     """The main entrypoint of the CLI"""
+    if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
+        print(f'Initialising Jina NOW v{version} ...')
+
     if not args:
         args = _get_run_args()
     args = vars(args)  # Make it a dict from Namespace

--- a/now/cli/__init__.py
+++ b/now/cli/__init__.py
@@ -11,6 +11,8 @@ from now import __version__ as version
 from now.deployment.deployment import cmd
 
 warnings.filterwarnings("ignore")
+if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
+    print(f'Initialising Jina NOW v{version} ...')
 
 cur_dir = pathlib.Path(__file__).parents[1].resolve()
 
@@ -113,8 +115,8 @@ def _get_kubectl_path() -> str:
 
 def cli(args=None):
     """The main entrypoint of the CLI"""
-    if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
-        print(f'Initialising Jina NOW v{version} ...')
+    # if len(sys.argv) != 1 and not ('-h' in sys.argv[1:] or '--help' in sys.argv[1:]):
+    #     print(f'Initialising Jina NOW v{version} ...')
 
     if not args:
         args = _get_run_args()

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
-NOW_PREPROCESSOR_VERSION = '0.0.88-fix-multiple-prints'
+NOW_PREPROCESSOR_VERSION = '0.0.88-fix-multiple-prints1'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-4'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
-NOW_PREPROCESSOR_VERSION = '0.0.87-secure-playground-3'
+NOW_PREPROCESSOR_VERSION = '0.0.88-fix-multiple-prints'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-4'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 DEMO_DATASET_DOCARRAY_VERSION = '0.13.17'
 
 DOCKER_BFF_PLAYGROUND_TAG = '0.0.127-secure-playgound-3'
-NOW_PREPROCESSOR_VERSION = '0.0.88-fix-multiple-prints1'
+NOW_PREPROCESSOR_VERSION = '0.0.88-refactor-request-size-4'
 NOW_ANNLITE_INDEXER_VERSION = '0.0.6-annlite-update-list-endpoint-4'
 
 


### PR DESCRIPTION
Fixes the first part of https://github.com/jina-ai/now/issues/539

Multiprocessing imports the `__init__` module for each process, resulting in printing `Initialising Jina NOW` several times. It's fixed by moving print statement into the `cli()` function.