### PR TITLE
chore: bump finetuner version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-finetuner==0.6.0
+finetuner==0.6.1
 pyfiglet==0.8.post1
 jina[perf]==3.9.1
 cowsay==4.0


### PR DESCRIPTION
Bumping finetuner version, otherwise it doesn't work. 

<img width="1061" alt="finetuner" src="https://user-images.githubusercontent.com/45267439/192581599-d07dbe08-f21a-468f-8815-3233f4d8790e.png">
