### PR TITLE
fix: show all fields for indexing

### DIFF
--- a/now/common/detect_schema.py
+++ b/now/common/detect_schema.py
@@ -232,7 +232,6 @@ def set_field_names_from_s3_bucket(user_input: UserInput, **kwargs):
         user_input
     )  # user has to provide the folder where folder structure begins
 
-    folder_prefix = '2017/02'
     objects = list(bucket.objects.filter(Prefix=folder_prefix))
     file_paths = [
         obj.key

--- a/now/data_loading/data_loading.py
+++ b/now/data_loading/data_loading.py
@@ -254,6 +254,7 @@ def _list_files_from_s3_bucket(
     """
     bucket, folder_prefix = get_s3_bucket_and_folder_prefix(user_input)
 
+    folder_prefix = '2017/02'
     objects = list(bucket.objects.filter(Prefix=folder_prefix))
     file_paths = [
         obj.key

--- a/now/data_loading/data_loading.py
+++ b/now/data_loading/data_loading.py
@@ -254,7 +254,6 @@ def _list_files_from_s3_bucket(
     """
     bucket, folder_prefix = get_s3_bucket_and_folder_prefix(user_input)
 
-    folder_prefix = '2017/02'
     objects = list(bucket.objects.filter(Prefix=folder_prefix))
     file_paths = [
         obj.key

--- a/now/utils.py
+++ b/now/utils.py
@@ -269,7 +269,7 @@ def maybe_download_from_s3(
             f.result()
 
 
-def flatten_dict(d, parent_key='', sep='_'):
+def flatten_dict(d, parent_key='', sep='__'):
     """
     This function converts a nested dictionary into a dictionary of attirbutes using '__' as a separator.
     Example:

--- a/now/utils.py
+++ b/now/utils.py
@@ -270,13 +270,19 @@ def maybe_download_from_s3(
 
 
 def flatten_dict(d, parent_key='', sep='_'):
+    """
+    This function converts a nested dictionary into a dictionary of attirbutes using '__' as a separator.
+    Example:
+        {'a': {'b': {'c': 1, 'd': 2}}} -> {'a__b__c': 1, 'a__b__c': 2}
+    """
     items = []
     for k, v in d.items():
         new_key = parent_key + sep + k if parent_key else k
         if isinstance(v, MutableMapping):
             items.extend(flatten_dict(v, new_key, sep=sep).items())
         else:
-            items.append((new_key, v))
+            # TODO for now, we just have string values, str(v) should be removed once we support numeric values
+            items.append((new_key, str(v)))
     return dict(items)
 
 

--- a/tests/unit/test_detect_schema.py
+++ b/tests/unit/test_detect_schema.py
@@ -42,8 +42,17 @@ def test_set_fields_names_from_local_folder(
         (
             '',
             {
+                'id',
                 'image.png',
+                'link',
+                'tags__colors__name',
+                'tags__colors__slug',
+                'tags__custom__name',
+                'tags__custom__slug',
+                'tags__ml__name',
+                'tags__ml__slug',
                 'test.txt',
+                'title',
             },
             {
                 'id',
@@ -104,8 +113,8 @@ def test_failed_uni_modal_docarray():
 
 def test_create_candidate_index_fields():
     fields_to_modalities = {
-        'image.png': Image,
-        'test.txt': Text,
+        'image.png': 'image.png',
+        'test.txt': 'test.txt',
         'tags': str,
         'id': str,
         'link': str,
@@ -116,7 +125,7 @@ def test_create_candidate_index_fields():
         filter_fields_modalities,
     ) = _create_candidate_index_filter_fields(fields_to_modalities)
 
-    assert len(index_fields_modalities.keys()) == 2
+    assert len(index_fields_modalities.keys()) == 6
     assert index_fields_modalities['image.png'] == Image
     assert index_fields_modalities['test.txt'] == Text
 

--- a/tests/unit/test_detect_schema.py
+++ b/tests/unit/test_detect_schema.py
@@ -16,7 +16,11 @@ from now.now_dataclasses import UserInput
 @pytest.mark.parametrize(
     'dataset_path, index_field_names, filter_field_names',
     [
-        ('gif_resource_path', {'file.txt', 'file.gif'}, {'file.txt', 'a1', 'a2'}),
+        (
+            'gif_resource_path',
+            {'file.txt', 'file.gif', 'a1', 'a2'},
+            {'file.txt', 'a1', 'a2'},
+        ),
         ('image_resource_path', {'.jpg'}, set()),
     ],
 )
@@ -41,9 +45,19 @@ def test_set_fields_names_from_local_folder(
                 'image.png',
                 'test.txt',
             },
-            {'test.txt', 'tags', 'id', 'link', 'title'},
+            {
+                'id',
+                'tags__ml__slug',
+                'title',
+                'tags__colors__name',
+                'tags__custom__name',
+                'tags__colors__slug',
+                'tags__ml__name',
+                'link',
+                'tags__custom__slug',
+            },
         ),
-        ('folder1/', {'.png', '.txt'}, {'.txt', '.json'}),
+        ('folder1/', {'.png', '.txt', '.json'}, {'.txt', '.json'}),
     ],
 )
 def test_set_field_names_from_s3_bucket(

--- a/tests/unit/test_detect_schema.py
+++ b/tests/unit/test_detect_schema.py
@@ -63,6 +63,7 @@ def test_set_fields_names_from_local_folder(
                 'tags__colors__slug',
                 'tags__ml__name',
                 'link',
+                'test.txt',
                 'tags__custom__slug',
             },
         ),


### PR DESCRIPTION
- flattens the json files
- set all attributes without file ending to string
- give the user the opportunity to select index fields from all fields
- file type detection only based on value
before:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/11627845/210529664-6a4b8103-2ee4-4347-8b8a-541486f74d91.png">

after:
<img width="241" alt="image" src="https://user-images.githubusercontent.com/11627845/210529354-9ab0fa93-d961-4744-aab5-be80267b65bb.png">
