### PR TITLE
fix: allow all as an options in filter

### DIFF
--- a/now/common/options.py
+++ b/now/common/options.py
@@ -55,7 +55,7 @@ def _check_index_field(user_input: UserInput, **kwargs):
 
 
 def _fill_filter_field_if_selected_all(user_input: UserInput, **kwargs):
-    if 'all' in user_input.filter_fields:
+    if '__all__' in user_input.filter_fields:
         user_input.filter_fields = list(
             user_input.filter_field_candidates_to_modalities.keys()
         )
@@ -68,7 +68,7 @@ def _append_all_option_to_filter(user_input: UserInput):
         if field not in user_input.index_fields
     ]
     if len(choices) > 1:
-        choices.append({'name': 'All of the above', 'value': 'all'})
+        choices.append({'name': 'All of the above', 'value': '__all__'})
     return choices
 
 

--- a/now/common/options.py
+++ b/now/common/options.py
@@ -41,6 +41,9 @@ AVAILABLE_SOON = 'will be available in upcoming versions'
 
 
 def _check_index_field(user_input: UserInput, **kwargs):
+    if not user_input.index_fields:
+        raise RetryException('Please select at least one index field')
+
     if (
         user_input.index_fields[0]
         not in user_input.index_field_candidates_to_modalities.keys()
@@ -49,6 +52,24 @@ def _check_index_field(user_input: UserInput, **kwargs):
             f'Index field specified is not among the index candidate fields. Please '
             f'choose one of the following: {user_input.index_field_candidates_to_modalities.keys()}'
         )
+
+
+def _fill_filter_field_if_selected_all(user_input: UserInput, **kwargs):
+    if 'all' in user_input.filter_fields:
+        user_input.filter_fields = list(
+            user_input.filter_field_candidates_to_modalities.keys()
+        )
+
+
+def _append_all_option_to_filter(user_input: UserInput):
+    choices = [
+        {'name': field, 'value': field}
+        for field in user_input.filter_field_candidates_to_modalities.keys()
+        if field not in user_input.index_fields
+    ]
+    if len(choices) > 1:
+        choices.append({'name': 'All of the above', 'value': 'all'})
+    return choices
 
 
 APP_NAME = DialogOptions(
@@ -207,11 +228,7 @@ INDEX_FIELDS = DialogOptions(
 
 FILTER_FIELDS = DialogOptions(
     name='filter_fields',
-    choices=lambda user_input, **kwargs: [
-        {'name': field, 'value': field}
-        for field in user_input.filter_field_candidates_to_modalities.keys()
-        if field not in user_input.index_fields
-    ],
+    choices=lambda user_input, **kwargs: _append_all_option_to_filter(user_input),
     prompt_message='Please select the filter fields',
     prompt_type='checkbox',
     depends_on=DATASET_TYPE,
@@ -222,7 +239,9 @@ FILTER_FIELDS = DialogOptions(
         - set(user_input.index_fields)
     )
     > 0,
+    post_func=_fill_filter_field_if_selected_all,
 )
+
 
 ES_INDEX_NAME = DialogOptions(
     name='es_index_name',


### PR DESCRIPTION
Allow `All of the above` as an option in the filter fields


When there's only one filter field
![image](https://user-images.githubusercontent.com/6537525/212692659-d64d347c-1ee7-4652-95a6-742ca73c660f.png)

When multiple filter fields
![image](https://user-images.githubusercontent.com/6537525/212692787-2c70d727-d760-4bba-a15d-8dd1be18e7f6.png)

---

- [ ] This PR references an open issue
- [ ] Test added
- [ ] Documentation adjusted
