### PR TITLE
chore: update pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,9 @@
-<!--- PR Description here --->
+<!--- Please add PR Description here --->
 
 
 ---
 
 - [ ] This PR references an open issue
-- [ ] Test added
-- [ ] Documentation adjusted
+- [ ] Added a test
+- [ ] Updated the documentation
+- [ ] Added a screenshot of a successful customer deployment


### PR DESCRIPTION
This PR just adds another checkbox to the PR template. For some time now, we have made it a requirement that all PR's should make a successful customer deployment and add a screenshot to the PR. So that this is not forgotten, we can add a check to the PR template. 
