### PR TITLE
fix: reload playground

### DIFF
--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -55,7 +55,7 @@ class SearchApp(JinaNOWApp):
             and 'NOW_CI_RUN' not in os.environ
         ):
             client = Client(
-                host=f'grpcs://{DEMO_NS.format(user_input.dataset_name.split("/")[-1])}.dev.jina.ai'
+                host=f'grpcs://{DEMO_NS.format(user_input.dataset_name.split("/")[-1])}.dev.jina.ai/flow'
             )
             try:
                 client.post('/dry_run', timeout=2)

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.1-refactor-custom-gateway-103'
+NOW_GATEWAY_VERSION = '0.0.2-fix-reload-playground-1'
 NOW_PREPROCESSOR_VERSION = '0.0.122-refactor-custom-gateway-103'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.147-fix-elastic-persistent-workspace-9'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.2-fix-reload-playground-1'
+NOW_GATEWAY_VERSION = '0.0.2-fix-reload-playground-2'
 NOW_PREPROCESSOR_VERSION = '0.0.122-refactor-custom-gateway-103'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.147-fix-elastic-persistent-workspace-9'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/executor/gateway/nginx.conf
+++ b/now/executor/gateway/nginx.conf
@@ -41,7 +41,7 @@ http  {
             proxy_pass http://localhost:8501/component;
         }
 
-        location /playground {
+        location / {
             # streamlit specific from https://discuss.streamlit.io/t/streamlit-docker-nginx-ssl-https/2195
             proxy_http_version 1.1;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -56,7 +56,7 @@ http  {
             proxy_pass http://localhost:8080;
         }
 
-        location / {
+        location /flow {
             proxy_pass http://localhost:8082;
         }
 

--- a/now/executor/gateway/now_gateway.py
+++ b/now/executor/gateway/now_gateway.py
@@ -31,7 +31,7 @@ class PlaygroundGateway(Gateway):
         streamlit.web.bootstrap._fix_pydeck_mapbox_api_warning()
         streamlit_cmd = (
             f'"python -m streamlit" run --browser.serverPort 12983 {self.streamlit_script} --server.address=0.0.0.0 '
-            f'--server.baseUrlPath /playground '
+            f'--server.baseUrlPath / '
         )
         if self.secured:
             streamlit_cmd += '-- --secured'

--- a/now/executor/gateway/playground/playground.py
+++ b/now/executor/gateway/playground/playground.py
@@ -247,7 +247,7 @@ def _do_login(params):
         query_params_var['top_k'] = params.top_k
     st.experimental_set_query_params(**query_params_var)
 
-    redirect_uri = f'{params.host}/playground'
+    redirect_uri = f'{params.host}'
     if 'top_k' in st.experimental_get_query_params():
         redirect_uri += f'?top_k={params.top_k}'
 

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -62,7 +62,7 @@ def start_now(**kwargs):
             gateway_host_internal,
         ) = run_backend.run(app_instance, user_input, **kwargs)
     bff_url = f'{gateway_host_internal}/api/v1/search-app/docs'
-    playground_url = f'{gateway_host_internal}/playground'
+    playground_url = f'{gateway_host_internal}'
 
     print()
     my_table = Table(

--- a/scripts/deploy_examples.py
+++ b/scripts/deploy_examples.py
@@ -117,7 +117,7 @@ if __name__ == '__main__':
     if deployment_type == 'partial':
         # check if deployment is already running then return
         client = Client(
-            host=f'grpcs://{DEMO_NS.format(to_deploy.name.split("/")[-1])}.dev.jina.ai'
+            host=f'grpcs://{DEMO_NS.format(to_deploy.name.split("/")[-1])}.dev.jina.ai/flow'
         )
         try:
             response = client.post('/dry_run', return_results=True)

--- a/tests/integration/remote/assertions.py
+++ b/tests/integration/remote/assertions.py
@@ -23,7 +23,7 @@ def assert_deployment_response(response):
     assert host.startswith('https://')
     assert host.endswith('.wolf.jina.ai')
     assert response['bff'] == f'{host}/api/v1/search-app/docs'
-    assert response['playground'] == f'{host}/playground'
+    assert response['playground'] == f'{host}'
 
 
 def assert_deployment_queries(


### PR DESCRIPTION
the playground automatically redirects to '/'
The proposed solution moves the playground to '/' and the flow to '/flow'. Therefore redirecting to '/' has no effect