### PR TITLE
feat: integrate es index manager

### DIFF
--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -152,6 +152,7 @@ class SearchApp(JinaNOWApp):
                     ],
                 ]
             )
+        provision_index = 'yes' if not testing else 'no'
 
         return {
             'name': 'indexer',
@@ -167,7 +168,7 @@ class SearchApp(JinaNOWApp):
             'jcloud': {
                 'labels': {
                     'app': 'indexer',
-                    'provision-index': 'yes',
+                    'provision-index': provision_index,
                 },
                 'resources': {
                     'memory': '8G',

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -154,6 +154,10 @@ class SearchApp(JinaNOWApp):
                     ],
                 ]
             )
+        if any['ES_HOSTS', 'ES_INDEX_NAME', 'API_KEY'] not in os.environ:
+            raise ValueError(
+                'Cannot find ES_HOSTS, ES_INDEX_NAME, API_KEY in environment variables'
+            )
 
         return {
             'name': 'indexer',
@@ -163,11 +167,17 @@ class SearchApp(JinaNOWApp):
             else 'NOWElasticIndexer',
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
             'uses_with': {
+                'hosts': os.environ['ES_HOSTS'],
+                'index_name': os.environ['ES_INDEX_NAME'],
+                'api_key': os.environ['API_KEY'],
                 'document_mappings': document_mappings_list,
-                'index_name': 'now_index' if not index_name else index_name,
             },
             'no_reduce': True,
             'jcloud': {
+                'labels': {
+                    'app': 'indexer',
+                    'es-index-manager/jinaai.provision-index': True,
+                },
                 'resources': {
                     'memory': '8G',
                     'cpu': 0.5,

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -129,14 +129,12 @@ class SearchApp(JinaNOWApp):
         user_input: UserInput,
         encoder2dim: Dict[str, int],
         testing=False,
-        index_name=None,
     ) -> Dict:
         """Creates indexer stub.
 
         :param user_input: user input
         :param encoder2dim: maps encoder name to its output dimension
         :param testing: use local executors if True
-        :param index_name: name of the elasticsearch index
         """
         document_mappings_list = []
 
@@ -216,7 +214,6 @@ class SearchApp(JinaNOWApp):
                 user_input,
                 encoder2dim=encoder2dim,
                 testing=testing,
-                index_name=kwargs.get('index_name'),
             )
         )
 

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -174,7 +174,6 @@ class SearchApp(JinaNOWApp):
                     'memory': '8G',
                     'cpu': 0.5,
                     'capacity': 'on-demand',
-                    'storage': {'kind': 'ebs', 'size': '10G'},
                 },
             },
         }

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -154,10 +154,6 @@ class SearchApp(JinaNOWApp):
                     ],
                 ]
             )
-        if any['ES_HOSTS', 'ES_INDEX_NAME', 'API_KEY'] not in os.environ:
-            raise ValueError(
-                'Cannot find ES_HOSTS, ES_INDEX_NAME, API_KEY in environment variables'
-            )
 
         return {
             'name': 'indexer',
@@ -167,9 +163,6 @@ class SearchApp(JinaNOWApp):
             else 'NOWElasticIndexer',
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
             'uses_with': {
-                'hosts': os.environ['ES_HOSTS'],
-                'index_name': os.environ['ES_INDEX_NAME'],
-                'api_key': os.environ['API_KEY'],
                 'document_mappings': document_mappings_list,
             },
             'no_reduce': True,

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -169,7 +169,7 @@ class SearchApp(JinaNOWApp):
             'jcloud': {
                 'labels': {
                     'app': 'indexer',
-                    'es-index-manager/jinaai.provision-index': True,
+                    'jinaai.provision-index': True,
                 },
                 'resources': {
                     'memory': '8G',

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -169,7 +169,7 @@ class SearchApp(JinaNOWApp):
             'jcloud': {
                 'labels': {
                     'app': 'indexer',
-                    'provisionindex': 'yes',
+                    'provision-index': 'yes',
                 },
                 'resources': {
                     'memory': '8G',

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -175,7 +175,7 @@ class SearchApp(JinaNOWApp):
                     'cpu': 0.5,
                     'capacity': 'on-demand',
                     'storage': {'kind': 'ebs', 'size': '10G'},
-                }
+                },
             },
         }
 

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -169,7 +169,7 @@ class SearchApp(JinaNOWApp):
             'jcloud': {
                 'labels': {
                     'app': 'indexer',
-                    'jinaai.provision-index': True,
+                    'provisionindex': 'yes',
                 },
                 'resources': {
                     'memory': '8G',

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-13'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-14'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-11'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-12'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-0'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-1'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-4'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-5'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.148-test-experiment-volume-8'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-0'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-2'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-3'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-8'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-9'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-7'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-8'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-16'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-17'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-6'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-7'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-1'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-2'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-12'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-13'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-5'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-6'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-9'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-10'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-14'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-16'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-10'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-11'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -6,7 +6,7 @@ from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-3'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-4'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 

--- a/now/executor/indexer/elastic/elastic_indexer.py
+++ b/now/executor/indexer/elastic/elastic_indexer.py
@@ -73,13 +73,14 @@ class NOWElasticIndexer(Executor):
         self.metric = metric
         self.limit = limit
         self.max_values_per_tag = max_values_per_tag
-        if all(v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'API_KEY']):
-            raise ValueError(
-                'Cannot find ES_HOSTS, ES_INDEX_NAME, API_KEY in environment variables'
+        if not all(v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'API_KEY']):
+            self.logger.info(
+                'es-index-manager not provisioning index, setting up own cluster'
             )
-        self.hosts = os.environ['ES_HOSTS']
-        self.api_key = os.environ['API_KEY']
-        self.index_name = os.environ['ES_INDEX_NAME']
+            self.setup_elastic_server()
+        self.hosts = os.getenv('ES_HOSTS', 'http://localhost:9200')
+        self.api_key = os.getenv('API_KEY', 'TestApiKey')
+        self.index_name = os.getenv('ES_INDEX_NAME', 'now-index')
         print(f'hosts: {self.hosts}')
         print(f'index_name: {self.index_name}')
         self.query_to_curated_ids = {}

--- a/now/executor/indexer/elastic/elastic_indexer.py
+++ b/now/executor/indexer/elastic/elastic_indexer.py
@@ -71,15 +71,13 @@ class NOWElasticIndexer(Executor):
         self.limit = limit
         self.max_values_per_tag = max_values_per_tag
         while not all(
-            v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'ES_API_KEY']
+            var in os.environ for var in ['ES_HOSTS', 'ES_INDEX_NAME', 'ES_API_KEY']
         ):
             self.logger.info('Environment variables not set yet. Waiting...')
             sleep(5)
         self.hosts = os.getenv('ES_HOSTS', 'http://localhost:9200')
         self.api_key = os.getenv('ES_API_KEY', 'TestApiKey')
         self.index_name = os.getenv('ES_INDEX_NAME', 'now-index')
-        print(f'hosts: {self.hosts}')
-        print(f'index_name: {self.index_name}')
         self.query_to_curated_ids = {}
         self.doc_id_tags = {}
         self.document_mappings = [FieldEmbedding(*dm) for dm in document_mappings]
@@ -95,18 +93,17 @@ class NOWElasticIndexer(Executor):
             **self.es_config,
             ssl_show_warn=False,
         )
-        self.do_health_check(self.es)
+        self._do_health_check()
         if not self.es.indices.exists(index=self.index_name):
             self.es.indices.create(index=self.index_name, mappings=self.es_mapping)
         else:
             self.es.indices.put_mapping(index=self.index_name, body=self.es_mapping)
 
-    @staticmethod
-    def do_health_check(es):
+    def _do_health_check(self):
         """Checks that Elasticsearch is up and running"""
         while True:
             try:
-                es.cluster.health(wait_for_status='yellow')
+                self.es.cluster.health(wait_for_status='yellow')
                 break
             except Exception:
                 sleep(1)

--- a/now/executor/indexer/elastic/elastic_indexer.py
+++ b/now/executor/indexer/elastic/elastic_indexer.py
@@ -72,10 +72,12 @@ class NOWElasticIndexer(Executor):
         self.metric = metric
         self.limit = limit
         self.max_values_per_tag = max_values_per_tag
-        if not all(v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'API_KEY']):
+        if not all(
+            v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'ES_API_KEY']
+        ):
             raise ValueError('es-index-manager not provisioning index')
         self.hosts = os.getenv('ES_HOSTS', 'http://localhost:9200')
-        self.api_key = os.getenv('API_KEY', 'TestApiKey')
+        self.api_key = os.getenv('ES_API_KEY', 'TestApiKey')
         self.index_name = os.getenv('ES_INDEX_NAME', 'now-index')
         print(f'hosts: {self.hosts}')
         print(f'index_name: {self.index_name}')

--- a/now/executor/indexer/elastic/elastic_indexer.py
+++ b/now/executor/indexer/elastic/elastic_indexer.py
@@ -45,7 +45,6 @@ class NOWElasticIndexer(Executor):
     def __init__(
         self,
         document_mappings: List[Tuple[str, int, List[str]]],
-        dim: int = None,
         metric: str = 'cosine',
         limit: int = 10,
         max_values_per_tag: int = 10,
@@ -57,7 +56,6 @@ class NOWElasticIndexer(Executor):
         """
         :param document_mappings: list of FieldEmbedding tuples that define which encoder
             encodes which fields, and the embedding size of the encoder.
-        :param dim: Dimensionality of vectors to index.
         :param metric: Distance metric type. Can be 'euclidean', 'inner_product', or 'cosine'
         :param limit: Number of results to get for each query document in search
         :param max_values_per_tag: Maximum number of values per tag
@@ -495,24 +493,3 @@ def aggregate_embeddings(docs_map: Dict[str, DocumentArray]):
                 if c.chunks[0].text or not c.uri:
                     c.content = c.chunks[0].content
                 c.chunks = DocumentArray()
-
-
-def wait_until_cluster_is_up(es, hosts):
-    MAX_RETRIES = 300
-    SLEEP = 1
-    retries = 0
-    while retries < MAX_RETRIES:
-        try:
-            if es.ping():
-                break
-            else:
-                retries += 1
-                sleep(SLEEP)
-        except Exception:
-            print(
-                f'Elasticsearch is not running yet, are you connecting to the right hosts? {hosts}'
-            )
-    if retries >= MAX_RETRIES:
-        raise RuntimeError(
-            f'Elasticsearch is not running after {MAX_RETRIES} retries ('
-        )

--- a/now/executor/indexer/elastic/elastic_indexer.py
+++ b/now/executor/indexer/elastic/elastic_indexer.py
@@ -51,9 +51,6 @@ class NOWElasticIndexer(Executor):
         limit: int = 10,
         max_values_per_tag: int = 10,
         es_mapping: Dict = None,
-        hosts: str = 'http://localhost:9200',
-        api_key: str = None,
-        index_name: str = 'now_index',
         es_config: Optional[Dict[str, Any]] = None,
         *args,
         **kwargs,
@@ -76,11 +73,15 @@ class NOWElasticIndexer(Executor):
         self.metric = metric
         self.limit = limit
         self.max_values_per_tag = max_values_per_tag
-        print(f'hosts: {hosts}')
-        print(f'index_name: {index_name}')
-        self.hosts = hosts
-        self.api_key = api_key
-        self.index_name = index_name
+        if all(v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'API_KEY']):
+            raise ValueError(
+                'Cannot find ES_HOSTS, ES_INDEX_NAME, API_KEY in environment variables'
+            )
+        self.hosts = os.environ['ES_HOSTS']
+        self.api_key = os.environ['API_KEY']
+        self.index_name = os.environ['ES_INDEX_NAME']
+        print(f'hosts: {self.hosts}')
+        print(f'index_name: {self.index_name}')
         self.query_to_curated_ids = {}
         self.doc_id_tags = {}
         self.document_mappings = [FieldEmbedding(*dm) for dm in document_mappings]

--- a/now/executor/indexer/elastic/elastic_indexer.py
+++ b/now/executor/indexer/elastic/elastic_indexer.py
@@ -70,10 +70,11 @@ class NOWElasticIndexer(Executor):
         self.metric = metric
         self.limit = limit
         self.max_values_per_tag = max_values_per_tag
-        if not all(
+        while not all(
             v in os.environ for v in ['ES_HOSTS', 'ES_INDEX_NAME', 'ES_API_KEY']
         ):
-            raise ValueError('es-index-manager not provisioning index')
+            self.logger.info('Environment variables not set yet. Waiting...')
+            sleep(5)
         self.hosts = os.getenv('ES_HOSTS', 'http://localhost:9200')
         self.api_key = os.getenv('ES_API_KEY', 'TestApiKey')
         self.index_name = os.getenv('ES_INDEX_NAME', 'now-index')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def setup_service_running(es_connection_params) -> None:
     cmd(f'docker-compose -f {docker_compose_file} up -d')
     hosts, _ = es_connection_params
     os.environ['ES_HOSTS'] = hosts
-    os.environ['API_KEY'] = 'TestApiKey'
+    os.environ['ES_API_KEY'] = 'TestApiKey'
     wait_until_cluster_is_up(es=Elasticsearch(hosts=hosts), hosts=hosts)
     yield
     cmd('docker-compose -f tests/resources/elastic/docker-compose.yml down')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,4 @@ def wait_until_cluster_is_up(es, hosts):
                 f'Elasticsearch is not running yet, are you connecting to the right hosts? {hosts}'
             )
     if retries >= MAX_RETRIES:
-        raise RuntimeError(
-            f'Elasticsearch is not running after {MAX_RETRIES} retries ('
-        )
+        raise RuntimeError(f'Elasticsearch is not running after {MAX_RETRIES} retries.')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ from urllib3.exceptions import InsecureRequestWarning, SecurityWarning
 
 from now.data_loading.elasticsearch import ElasticsearchConnector
 from now.deployment.deployment import cmd
-from now.executor.indexer.elastic.elastic_indexer import wait_until_cluster_is_up
 from now.executor.preprocessor import NOWPreprocessor
 from now.utils import get_aws_profile
 
@@ -328,3 +327,24 @@ def setup_online_shop_db(setup_elastic_db, es_connection_params, online_shop_res
 
     # delete index
     delete_es_index(connector=es_connector, name=index_name)
+
+
+def wait_until_cluster_is_up(es, hosts):
+    MAX_RETRIES = 300
+    SLEEP = 1
+    retries = 0
+    while retries < MAX_RETRIES:
+        try:
+            if es.ping():
+                break
+            else:
+                retries += 1
+                sleep(SLEEP)
+        except Exception:
+            print(
+                f'Elasticsearch is not running yet, are you connecting to the right hosts? {hosts}'
+            )
+    if retries >= MAX_RETRIES:
+        raise RuntimeError(
+            f'Elasticsearch is not running after {MAX_RETRIES} retries ('
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@
 import base64
 import os
 import random
+import time
 from collections import namedtuple
 from warnings import catch_warnings, filterwarnings
 
@@ -339,7 +340,7 @@ def wait_until_cluster_is_up(es, hosts):
                 break
             else:
                 retries += 1
-                sleep(SLEEP)
+                time.sleep(SLEEP)
         except Exception:
             print(
                 f'Elasticsearch is not running yet, are you connecting to the right hosts? {hosts}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,6 +162,8 @@ def setup_service_running(es_connection_params) -> None:
     )
     cmd(f'docker-compose -f {docker_compose_file} up -d')
     hosts, _ = es_connection_params
+    os.environ['ES_HOSTS'] = hosts
+    os.environ['API_KEY'] = 'TestApiKey'
     wait_until_cluster_is_up(es=Elasticsearch(hosts=hosts), hosts=hosts)
     yield
     cmd('docker-compose -f tests/resources/elastic/docker-compose.yml down')
@@ -180,6 +182,11 @@ def get_aws_info():
         aws_profile.aws_secret_access_key,
         region,
     )
+
+
+@pytest.fixture
+def random_index_name():
+    os.environ['ES_INDEX_NAME'] = f"test-index-{random.randint(0, 10000)}"
 
 
 @pytest.fixture
@@ -321,8 +328,3 @@ def setup_online_shop_db(setup_elastic_db, es_connection_params, online_shop_res
 
     # delete index
     delete_es_index(connector=es_connector, name=index_name)
-
-
-@pytest.fixture
-def random_index_name():
-    return f'test-index-{random.randint(0, 10000)}'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,7 @@ def es_connection_params():
 
 
 @pytest.fixture(scope='session')
-def setup_service_running(es_connection_params, random_index_name) -> None:
+def setup_service_running(es_connection_params) -> None:
     docker_compose_file = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         'resources/elastic/docker-compose.yml',
@@ -183,7 +183,7 @@ def get_aws_info():
     )
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture
 def random_index_name():
     os.environ['ES_INDEX_NAME'] = f"test-index-{random.randint(0, 10000)}"
 
@@ -331,7 +331,7 @@ def setup_online_shop_db(setup_elastic_db, es_connection_params, online_shop_res
 
 def wait_until_cluster_is_up(es, hosts):
     MAX_RETRIES = 300
-    SLEEP = 1
+    SLEEP = 3
     retries = 0
     while retries < MAX_RETRIES:
         try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,7 +154,7 @@ def es_connection_params():
 
 
 @pytest.fixture(scope='session')
-def setup_service_running(es_connection_params) -> None:
+def setup_service_running(es_connection_params, random_index_name) -> None:
     docker_compose_file = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
         'resources/elastic/docker-compose.yml',
@@ -183,7 +183,7 @@ def get_aws_info():
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def random_index_name():
     os.environ['ES_INDEX_NAME'] = f"test-index-{random.randint(0, 10000)}"
 

--- a/tests/executor/indexer/test_elastic_in_flow.py
+++ b/tests/executor/indexer/test_elastic_in_flow.py
@@ -33,7 +33,6 @@ def flow(random_index_name, metas):
             self.preprocessor = NOWPreprocessor()
             self.encoder = DummyEncoder()
             self.indexer = NOWElasticIndexer(
-                hosts='http://localhost:9200',
                 document_mappings=DOCUMENT_MAPPINGS,
                 user_input_dict={
                     'filter_fields': ['color', 'greeting'],

--- a/tests/executor/indexer/test_elastic_in_flow.py
+++ b/tests/executor/indexer/test_elastic_in_flow.py
@@ -34,7 +34,6 @@ def flow(random_index_name, metas):
             self.encoder = DummyEncoder()
             self.indexer = NOWElasticIndexer(
                 hosts='http://localhost:9200',
-                index_name=random_index_name,
                 document_mappings=DOCUMENT_MAPPINGS,
                 user_input_dict={
                     'filter_fields': ['color', 'greeting'],

--- a/tests/executor/indexer/test_es_converter.py
+++ b/tests/executor/indexer/test_es_converter.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 from docarray import Document
 from docarray.score import NamedScore
@@ -24,9 +26,10 @@ def test_convert_doc_map_to_es(es_inputs, random_index_name):
     encoder_to_fields = {document_mappings[0]: document_mappings[2]}
     first_doc_clip = index_docs_map['clip'][0]
     aggregate_embeddings(index_docs_map)
+    index_name = os.getenv('ES_INDEX_NAME')
     first_result = convert_doc_map_to_es(
         docs_map=index_docs_map,
-        index_name=random_index_name,
+        index_name=index_name,
         encoder_to_fields=encoder_to_fields,
     )[0]
     assert first_result['id'] == first_doc_clip.id

--- a/tests/executor/indexer/test_executor.py
+++ b/tests/executor/indexer/test_executor.py
@@ -1,5 +1,4 @@
 import os
-import tempfile
 
 from now.executor.indexer.elastic.elastic_indexer import (
     FieldEmbedding,
@@ -280,24 +279,3 @@ def test_search_with_filter(setup_service_running, es_inputs, random_index_name)
     )
     assert len(res[0].matches) == 1
     assert res[0].matches[0].tags['price'] < 1
-
-
-def test_configure_local_cluster(setup_service_running, es_inputs, random_index_name):
-    """
-    This test tests the configure_local_cluster function of the NOWElasticIndexer.
-    """
-    with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_elastic_search_conf_path = tmpdir + '/elasticsearch.yml'
-        NOWElasticIndexer.configure_elastic(tmpdir, tmp_elastic_search_conf_path)
-
-        with open(tmp_elastic_search_conf_path, 'r') as f:
-            content = [line for line in f.readlines()]
-        assert content == [
-            'cluster.name: "docker-cluster"\n',
-            'network.host: 0.0.0.0\n',
-            'xpack.security.enabled: false\n',
-            'discovery.type: single-node\n',
-            'path:\n',
-            f'  data: {tmpdir}/data\n',
-            f'  logs: {tmpdir}/logs',
-        ]

--- a/tests/executor/indexer/test_executor.py
+++ b/tests/executor/indexer/test_executor.py
@@ -128,8 +128,6 @@ def test_count_endpoint(setup_service_running, es_inputs, random_index_name):
     ) = es_inputs
     es_indexer = NOWElasticIndexer(
         document_mappings=document_mappings,
-        hosts='http://localhost:9200',
-        index_name=random_index_name,
     )
     es_indexer.index(index_docs_map)
     result = es_indexer.count()

--- a/tests/integration/local/conftest.py
+++ b/tests/integration/local/conftest.py
@@ -10,12 +10,12 @@ from jina import Flow
 
 from now.admin.utils import get_default_request_body
 from now.common.options import construct_app
-from now.constants import DatasetTypes, Models, Apps
+from now.constants import Apps, DatasetTypes, Models
 from now.data_loading.create_dataclass import create_dataclass
 from now.data_loading.data_loading import load_data
 from now.demo_data import DemoDatasetNames
 from now.now_dataclasses import UserInput
-from now.utils import write_flow_file, get_aws_profile
+from now.utils import get_aws_profile, write_flow_file
 
 BASE_URL = 'http://localhost:8081/api/v1'
 SEARCH_URL = f'{BASE_URL}/search-app/search'
@@ -49,15 +49,12 @@ class FlowThread(multiprocessing.Process):
         self,
         event,
         user_input,
-        random_index_name,
         tmpdir,
     ):
         multiprocessing.Process.__init__(self)
 
         self.event = event
-        user_input.app_instance.setup(
-            user_input=user_input, testing=True, index_name=random_index_name
-        )
+        user_input.app_instance.setup(user_input=user_input, testing=True)
         for executor in user_input.app_instance.flow_yaml['executors']:
             if not executor.get('external'):
                 executor['uses_metas'] = {'workspace': str(tmpdir)}

--- a/tests/integration/local/conftest.py
+++ b/tests/integration/local/conftest.py
@@ -31,7 +31,7 @@ def get_flow(request, random_index_name, tmpdir):
     params = request.param
     docs, user_input = request.getfixturevalue(params)
     event = multiprocessing.Event()
-    flow = FlowThread(event, user_input, random_index_name, tmpdir)
+    flow = FlowThread(event, user_input, tmpdir)
     flow.start()
     while not flow.is_flow_ready():
         sleep(1)

--- a/tests/integration/local/test_end_to_end.py
+++ b/tests/integration/local/test_end_to_end.py
@@ -23,7 +23,7 @@ from now.constants import ACCESS_PATHS
     ],
     indirect=True,
 )
-def test_end_to_end(get_flow, setup_service_running):
+def test_end_to_end(get_flow, setup_service_running, random_index_name):
     docs, user_input = get_flow
     client = Client(host='grpc://localhost:8085')
 

--- a/tests/integration/offline_flow/flow.py
+++ b/tests/integration/offline_flow/flow.py
@@ -1,4 +1,3 @@
-import random
 from typing import Dict
 
 import numpy as np
@@ -31,8 +30,6 @@ class OfflineFlow:
         self.indexer = NOWElasticIndexer(
             user_input_dict=user_input_dict,
             document_mappings=document_mappings,
-            hosts='http://localhost:9200',
-            index_name=f"test-index-{random.randint(0, 10000)}",
         )
         self.mock_client(monkeypatch)
 

--- a/tests/integration/offline_flow/test_offline_flow.py
+++ b/tests/integration/offline_flow/test_offline_flow.py
@@ -11,7 +11,9 @@ from now.now_dataclasses import UserInput
 
 
 @pytest.mark.asyncio
-async def test_docarray(monkeypatch, setup_service_running, multi_modal_data):
+async def test_docarray(
+    monkeypatch, setup_service_running, random_index_name, multi_modal_data
+):
     """
     Test all executors and bff together without creating a flow.
     The Clip Encoder is mocked because it is an external executor.


### PR DESCRIPTION
<!--- Please add PR Description here --->
In this PR, the setup of elasticsearch in the cluster is removed. As such, the indexer no longer directly creates and configures the elasticsearch instance. Instead, this resource is provisioned by the `es-index-manager` (see [this repo](https://github.com/jina-ai/es-index-manager) for more info). The `es-index-manager` operator looks for the label `provision-index: "yes"` on our deployment in order to provision resources for it. This label should be found under the`spec.template.metadata.labels`, as shown below in the screenshot. If this label is not present, the operator will not create indices. When the deployment is cleaned up and removed, the operator will take note and also remove the index.

<img width="362" alt="Screenshot 2023-02-20 at 09 35 45" src="https://user-images.githubusercontent.com/55404563/220054163-06dad59e-9efb-4f65-8221-8280b40f404b.png">

In the case of local integration tests, as well as offline flow tests, fixtures such as `setup_service_running` will ensure the setup of a local elasticsearch instance.

Screenshot of working customer deployment:
<img width="754" alt="Screenshot 2023-02-20 at 09 27 32" src="https://user-images.githubusercontent.com/55404563/220052335-550a3e39-f0f1-4fbb-bce8-2662794d5fbc.png">

---

- [x] This PR references an open issue
- [x] Added a test
- [ ] Updated the documentation
- [ ] Added a screenshot of a successful customer deployment
