### PR TITLE
feat: add a dummy query to app so logs get flushed

### DIFF
--- a/now/deployment/deployment.py
+++ b/now/deployment/deployment.py
@@ -1,7 +1,11 @@
 import asyncio
 import subprocess
 
+import hubble
+from docarray import dataclass
+from docarray.typing import Text
 from jcloud.flow import CloudFlow
+from jina import Client, Document
 
 
 def deploy_wolf(path: str):
@@ -59,3 +63,17 @@ def cmd(command, std_output=False, wait=True):
 
 def which(executable: str) -> bool:
     return bool(cmd('which ' + executable)[0])
+
+
+def dummy_query(host: str) -> None:
+    @dataclass
+    class MMQuery:
+        query_text: Text
+
+    print(host)
+    client = Client(host=host)
+    client.post(
+        on='/search',
+        inputs=Document(MMQuery(query_text="test")),
+        parameters={'jwt': {'token': hubble.get_token()}, 'access_paths': '@cc'},
+    )

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -7,7 +7,13 @@ from rich.table import Column, Table
 
 from now import run_backend
 from now.constants import DEMO_NS, FLOW_STATUS
-from now.deployment.deployment import cmd, list_all_wolf, status_wolf, terminate_wolf
+from now.deployment.deployment import (
+    cmd,
+    dummy_query,
+    list_all_wolf,
+    status_wolf,
+    terminate_wolf,
+)
 from now.dialog import configure_user_input
 from now.utils import maybe_prompt_user
 
@@ -115,6 +121,10 @@ def fetch_logs_now(**kwargs):
             }
         ]
         cluster = maybe_prompt_user(questions, 'cluster', **kwargs)
+
+    app_host = cluster.split("://")[1]
+    app_url = f"https://{app_host}"  # can be changed to grpc in the future
+    dummy_query(app_url)
 
     flow = [x for x in alive_flows if x['name'] == cluster][0]
     flow_id = flow['id']

--- a/now/run_all_k8s.py
+++ b/now/run_all_k8s.py
@@ -122,9 +122,7 @@ def fetch_logs_now(**kwargs):
         ]
         cluster = maybe_prompt_user(questions, 'cluster', **kwargs)
 
-    app_host = cluster.split("://")[1]
-    app_url = f"https://{app_host}"  # can be changed to grpc in the future
-    dummy_query(app_url)
+    dummy_query(cluster)
 
     flow = [x for x in alive_flows if x['name'] == cluster][0]
     flow_id = flow['id']


### PR DESCRIPTION
<!--- Please add PR Description here --->
This PR allows sending a dummy query to a running app. This is a trick that can be used to flush the stdout on the pods, allowing to query the complete logs, as otherwise they are sometimes truncated.

---

- [ ] This PR references an open issue
- [ ] Added a test
- [ ] Updated the documentation
- [ ] Added a screenshot of a successful customer deployment
