### PR TITLE
fix: update semantic scores based on dataclass fields of query

### DIFF
--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-4'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-5'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-7'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-8'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-5'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-6'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,8 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-11'
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-12'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-13'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-0'
 NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-17'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-13'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-14'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-9'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-10'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-6'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-7'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-10'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-11'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-2'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-3'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-8'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-9'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-3'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-4'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-1'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-2'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/constants.py
+++ b/now/constants.py
@@ -5,9 +5,10 @@ from docarray.typing import Image, Text, Video
 from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-11'
-NOW_PREPROCESSOR_VERSION = '0.0.124-fix-use-spot-0'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-use-spot-0'
-NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-use-spot-0'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-12'
+NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-1'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-compare-flows-27'
+NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 
 
 class Apps(BetterEnum):

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-0'
+NOW_GATEWAY_VERSION = '0.0.4-fix-sem-scores-query-field-1'
 NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-no-batchwise-indexing-2'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-17'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -5,6 +5,7 @@ from docarray import Document
 from fastapi import APIRouter, Body
 
 from now.data_loading.create_dataclass import create_dataclass
+from now.executor.gateway.bff.app.settings import user_input_in_bff
 from now.executor.gateway.bff.app.v1.models.search import (
     SearchRequestModel,
     SearchResponseModel,
@@ -142,6 +143,14 @@ async def search(
     for sem_score in data.semantic_scores:
         sem_score = list(sem_score)
         sem_score[0] = field_names_to_dataclass_fields[sem_score[0]]
+        try:
+            sem_score[1] = user_input_in_bff.field_names_to_dataclass_fields[
+                sem_score[1]
+            ]
+        except:
+            raise ValueError(
+                f'Field {sem_score[1]} not found in dataclass. Please select possible values: {user_input_in_bff.field_names_to_dataclass_fields.keys()}'
+            )
         semantic_scores.append(sem_score)
 
     query_filter = {}

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -137,6 +137,13 @@ async def search(
         modalities_dict=fields_modalities_mapping,
         field_names_to_dataclass_fields=field_names_to_dataclass_fields,
     )
+    # update semantic scores query field to mirror dataclass fields of query
+    semantic_scores = []
+    for sem_score in data.semantic_scores:
+        sem_score = list(sem_score)
+        sem_score[0] = field_names_to_dataclass_fields[sem_score[0]]
+        semantic_scores.append(sem_score)
+
     query_filter = {}
     for key, value in data.filters.items():
         key = 'tags__' + key if not key.startswith('tags__') else key
@@ -149,9 +156,7 @@ async def search(
             'limit': data.limit,
             'filter': query_filter,
             'create_temp_link': data.create_temp_link,
-            'semantic_scores': [
-                list(semantic_score) for semantic_score in data.semantic_scores
-            ],
+            'semantic_scores': semantic_scores,
             'get_score_breakdown': data.get_score_breakdown,
         },
         request_model=data,

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -1,5 +1,5 @@
 import base64
-from typing import List
+from typing import Any, Dict, List
 
 from docarray import Document
 from fastapi import APIRouter, Body
@@ -138,21 +138,7 @@ async def search(
         modalities_dict=fields_modalities_mapping,
         field_names_to_dataclass_fields=field_names_to_dataclass_fields,
     )
-    # update semantic scores query field to mirror dataclass fields of query
-    semantic_scores = []
-    for sem_score in data.semantic_scores:
-        sem_score = list(sem_score)
-        sem_score[0] = field_names_to_dataclass_fields[sem_score[0]]
-        try:
-            sem_score[1] = user_input_in_bff.field_names_to_dataclass_fields[
-                sem_score[1]
-            ]
-        except KeyError:
-            if sem_score[1] != 'bm25_text':
-                raise KeyError(
-                    f'Field {sem_score[1]} not found in dataclass. Please select possible values: {user_input_in_bff.field_names_to_dataclass_fields.keys()}'
-                )
-        semantic_scores.append(sem_score)
+    semantic_scores = get_semantic_scores(data, field_names_to_dataclass_fields)
 
     query_filter = {}
     for key, value in data.filters.items():
@@ -209,6 +195,37 @@ async def search(
         )
         matches.append(match)
     return matches
+
+
+def get_semantic_scores(
+    data: SearchRequestModel, field_names_to_dataclass_fields: Dict[str, str]
+) -> List[List[Any]]:
+    """
+    Extract and process the semantic scores from the request model to the format expected by the indexer.
+    This includes converting the field names to the dataclass field names, for the query and for the index fields.
+    Because `bm25_text` is not a field in the dataclass, it is not converted. It is a special field created by the
+    indexer for the bm25 score.
+
+    :param data: the request model
+    :param field_names_to_dataclass_fields: a mapping from the field names in the request model to the field names in the dataclass
+    :return: the semantic scores in the format expected by the indexer. Example:
+        [['query_text', 'my_product_image', 'encoderclip', 1], ['query_text', 'bm25_text', 'bm25', 1]]
+    """
+    semantic_scores = []
+    for sem_score in data.semantic_scores:
+        sem_score = list(sem_score)
+        sem_score[0] = field_names_to_dataclass_fields[sem_score[0]]
+        try:
+            sem_score[1] = user_input_in_bff.field_names_to_dataclass_fields[
+                sem_score[1]
+            ]
+        except KeyError:
+            if sem_score[1] != 'bm25_text':
+                raise KeyError(
+                    f'Field {sem_score[1]} not found in dataclass. Please select possible values: {user_input_in_bff.field_names_to_dataclass_fields.keys()}'
+                )
+        semantic_scores.append(sem_score)
+    return semantic_scores
 
 
 @router.post(

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -147,10 +147,11 @@ async def search(
             sem_score[1] = user_input_in_bff.field_names_to_dataclass_fields[
                 sem_score[1]
             ]
-        except:
-            raise ValueError(
-                f'Field {sem_score[1]} not found in dataclass. Please select possible values: {user_input_in_bff.field_names_to_dataclass_fields.keys()}'
-            )
+        except KeyError:
+            if sem_score[1] != 'bm25_text':
+                raise KeyError(
+                    f'Field {sem_score[1]} not found in dataclass. Please select possible values: {user_input_in_bff.field_names_to_dataclass_fields.keys()}'
+                )
         semantic_scores.append(sem_score)
 
     query_filter = {}

--- a/now/executor/gateway/playground/playground.py
+++ b/now/executor/gateway/playground/playground.py
@@ -353,6 +353,7 @@ def toggle_bm25_slider():
 
 
 def get_encoder_options(q_field: str, id_field: str) -> List[str]:
+    id_field = st.session_state.field_names_to_dataclass_fields[id_field]
     encoders_options = [
         encoder
         for encoder in st.session_state.index_fields_dict.keys()

--- a/now/executor/gateway/playground/playground.py
+++ b/now/executor/gateway/playground/playground.py
@@ -425,7 +425,6 @@ def customize_semantic_scores():
             options=list(st.session_state.field_names_to_dataclass_fields.keys()),
             key='index_field_' + str(i),
         )
-        id_field = st.session_state.field_names_to_dataclass_fields[id_field]
         encoder_options = get_encoder_options(q_field, id_field)
         enc = encoder.selectbox(
             label='encoder',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """ Module holds reusable fixtures """
 import base64
+import json
 import os
 import random
 import time
@@ -152,6 +153,14 @@ def es_connection_params():
     connection_str = 'http://localhost:9200'
     connection_args = {'verify_certs': False}
     return connection_str, connection_args
+
+
+@pytest.fixture(scope="function")
+def dump_user_input(request) -> None:
+    with open(os.path.join(os.path.expanduser('~'), 'user_input.json'), 'w') as f:
+        json.dump(request.param.__dict__, f)
+    yield
+    os.remove(os.path.join(os.path.expanduser('~'), 'user_input.json'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -157,6 +157,10 @@ def es_connection_params():
 
 @pytest.fixture(scope="function")
 def dump_user_input(request) -> None:
+    # If user_input.json exists, then remove it
+    if os.path.exists(os.path.join(os.path.expanduser('~'), 'user_input.json')):
+        os.remove(os.path.join(os.path.expanduser('~'), 'user_input.json'))
+    # Now dump the user input
     with open(os.path.join(os.path.expanduser('~'), 'user_input.json'), 'w') as f:
         json.dump(request.param.__dict__, f)
     yield

--- a/tests/integration/offline_flow/test_offline_flow.py
+++ b/tests/integration/offline_flow/test_offline_flow.py
@@ -20,7 +20,7 @@ def get_user_input():
     return user_input
 
 
-@pytest.mark.parametrize('dump_user_input', [get_user_input], indirect=True)
+@pytest.mark.parametrize('dump_user_input', [get_user_input()], indirect=True)
 @pytest.mark.asyncio
 async def test_docarray(
     dump_user_input,

--- a/tests/integration/offline_flow/test_offline_flow.py
+++ b/tests/integration/offline_flow/test_offline_flow.py
@@ -21,6 +21,11 @@ async def test_docarray(
     """
     user_input = UserInput()
     user_input.index_fields = ['product_title', 'product_description', 'product_image']
+    user_input.field_names_to_dataclass_fields = {
+        'product_title': 'product_title',
+        'product_description': 'product_description',
+        'product_image': 'product_image',
+    }
 
     offline_flow = OfflineFlow(monkeypatch, user_input_dict=user_input.__dict__)
 

--- a/tests/integration/offline_flow/test_offline_flow.py
+++ b/tests/integration/offline_flow/test_offline_flow.py
@@ -34,6 +34,7 @@ async def test_docarray(
     search_result = await search(
         SearchRequestModel(
             query=[{'name': 'text', 'value': 'girl on motorbike', 'modality': 'text'}],
+            semantic_scores=[('text', 'product_title', 'encoderclip', 1.0)],
         )
     )
     assert search_result[0].fields['product_title'].text == 'fancy title'

--- a/tests/integration/remote/assertions.py
+++ b/tests/integration/remote/assertions.py
@@ -48,7 +48,7 @@ def assert_deployment_queries(
     assert_search(search_url, request_body)
     # add semantic scores to the request body, assert search still works
     request_body['semantic_scores'] = [
-        [[request_body['query']['name']], index_fields[0], 'encoderclip', 0.8]
+        [[request_body['query'][0]['name']], index_fields[0], 'encoderclip', 0.8]
     ]
     assert_search(search_url, request_body)
 

--- a/tests/integration/remote/assertions.py
+++ b/tests/integration/remote/assertions.py
@@ -48,7 +48,7 @@ def assert_deployment_queries(
     assert_search(search_url, request_body)
     # add semantic scores to the request body, assert search still works
     request_body['semantic_scores'] = [
-        [[request_body['query'][0]['name']], index_fields[0], 'encoderclip', 0.8]
+        [request_body['query'][0]['name'], index_fields[0], 'encoderclip', 0.8]
     ]
     assert_search(search_url, request_body)
 

--- a/tests/integration/remote/assertions.py
+++ b/tests/integration/remote/assertions.py
@@ -30,6 +30,7 @@ def assert_deployment_response(response):
 
 
 def assert_deployment_queries(
+    index_fields,
     kwargs,
     response,
     search_modality,
@@ -44,6 +45,11 @@ def assert_deployment_queries(
         dataset=dataset,
     )
     search_url = f'{url}/search-app/search'
+    assert_search(search_url, request_body)
+    # add semantic scores to the request body, assert search still works
+    request_body['semantic_scores'] = [
+        [[request_body['query']['name']], index_fields[0], 'encoderclip', 0.8]
+    ]
     assert_search(search_url, request_body)
 
     if kwargs.secured:

--- a/tests/integration/remote/test_e2e_docarray.py
+++ b/tests/integration/remote/test_e2e_docarray.py
@@ -97,6 +97,7 @@ def test_end_to_end(
 
     assert_deployment_response(response)
     assert_deployment_queries(
+        index_fields=index_fields,
         kwargs=kwargs,
         response=response,
         search_modality='text',

--- a/tests/integration/remote/test_e2e_elastic.py
+++ b/tests/integration/remote/test_e2e_elastic.py
@@ -47,6 +47,7 @@ def test_end_to_end(
 
     assert_deployment_response(response)
     assert_deployment_queries(
+        index_fields=['title'],
         kwargs=kwargs,
         response=response,
         search_modality='text',

--- a/tests/integration/remote/test_e2e_local_folder.py
+++ b/tests/integration/remote/test_e2e_local_folder.py
@@ -43,6 +43,7 @@ def test_end_to_end(
 
     assert_deployment_response(response)
     assert_deployment_queries(
+        index_fields=['image.png', 'test.txt'],
         kwargs=kwargs,
         response=response,
         search_modality='text',

--- a/tests/unit/bff/conftest.py
+++ b/tests/unit/bff/conftest.py
@@ -6,8 +6,6 @@ from docarray import DocumentArray
 from fastapi.testclient import TestClient
 from pytest_mock import MockerFixture
 
-from now.executor.gateway.bff.app.app import build_app
-
 data_url = 'https://storage.googleapis.com/jina-fashion-data/data/one-line/datasets/jpeg/best-artworks.img10.bin'
 
 
@@ -47,6 +45,8 @@ class MockedJinaClient:
 
 @pytest.fixture
 def client() -> Generator[requests.Session, None, None]:
+    from now.executor.gateway.bff.app.app import build_app
+
     with TestClient(build_app()) as client:
         yield client
 
@@ -56,6 +56,8 @@ def client_with_mocked_jina_client(
     mocker: MockerFixture,
 ) -> Callable[[DocumentArray], requests.Session]:
     def _fixture(response: DocumentArray) -> requests.Session:
+        from now.executor.gateway.bff.app.app import build_app
+
         def _get_jina_streamer():
             return MockedJinaClient(response)
 

--- a/tests/unit/bff/v1/routers/test_info.py
+++ b/tests/unit/bff/v1/routers/test_info.py
@@ -1,9 +1,12 @@
 import json
 from typing import Callable
 
+import pytest
 import requests
 from docarray import DocumentArray
 from starlette import status
+
+from now.now_dataclasses import UserInput
 
 
 def test_tags_response(
@@ -44,23 +47,32 @@ def test_count_response(
     assert json.loads(response.content)['number_of_docs'] == 1
 
 
+def get_user_input() -> UserInput:
+    user_input = UserInput()
+    user_input.index_fields = ['text.txt', 'image.png']
+    user_input.field_names_to_dataclass_fields = {
+        'text.txt': 'text_0',
+        'image.png': 'image_0',
+    }
+    return user_input
+
+
+@pytest.mark.parametrize('dump_user_input', [get_user_input()], indirect=True)
 def test_field_names_to_dataclass_fields_response(
+    dump_user_input,
     client_with_mocked_jina_client: Callable[[DocumentArray], requests.Session],
     sample_search_response_text: DocumentArray,
     base64_image_string: str,
 ):
     response = client_with_mocked_jina_client(sample_search_response_text).post(
         '/api/v1/info/field_names_to_dataclass_fields',
-        json={
-            'query': [
-                {'name': 'blob', 'value': base64_image_string, 'modality': 'image'},
-                {'name': 'text', 'value': 'Hello', 'modality': 'text'},
-            ]
-        },
     )
 
     assert response.status_code == status.HTTP_200_OK
-    assert json.loads(response.content)['field_names_to_dataclass_fields'] == {}
+    assert json.loads(response.content)['field_names_to_dataclass_fields'] == {
+        'text.txt': 'text_0',
+        'image.png': 'image_0',
+    }
 
 
 def test_encoder_to_dataclass_fields_mods_response(

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -5,6 +5,8 @@ import requests
 from docarray import Document, DocumentArray
 from starlette import status
 
+from now.now_dataclasses import UserInput
+
 
 def test_text_search_fails_with_incorrect_query(client):
     with pytest.raises(ValueError):
@@ -107,7 +109,16 @@ def test_image_search_parse_response(
     assert results[0].text == sample_search_response_text[0].matches[0].chunks[0].text
 
 
+def get_user_input() -> UserInput:
+    user_input = UserInput()
+    user_input.index_fields = ['text']
+    user_input.field_names_to_dataclass_fields = {'text': 'text'}
+    return user_input
+
+
+@pytest.mark.parametrize('dump_user_input', [get_user_input()], indirect=True)
 def test_text_search_with_semantic_scores(
+    dump_user_input,
     client_with_mocked_jina_client: Callable[[DocumentArray], requests.Session],
     sample_search_response_text: DocumentArray,
     base64_image_string: str,

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -141,5 +141,5 @@ def test_text_search_with_semantic_scores(
     # the mock writes the call args into the response tags
     assert results[0].tags['parameters']['semantic_scores']
     assert results[0].tags['parameters']['semantic_scores'] == [
-        ['text_0', 'text', 'clip', 1]
+        ['text_0', 'image_0', 'clip', 1]
     ]

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -132,7 +132,10 @@ def test_text_search_with_semantic_scores(
             'query': [
                 {'name': 'text', 'value': 'this crazy text', 'modality': 'text'},
             ],
-            'semantic_scores': [['text', 'image.png', 'clip', 1]],
+            'semantic_scores': [
+                ['text', 'image.png', 'clip', 1],
+                ['text', 'bm25_text', 'bm25', 1],
+            ],
         },
     )
 

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -132,7 +132,7 @@ def test_text_search_with_semantic_scores(
             'query': [
                 {'name': 'text', 'value': 'this crazy text', 'modality': 'text'},
             ],
-            'semantic_scores': [['text', 'text', 'clip', 1]],
+            'semantic_scores': [['text', 'image.png', 'clip', 1]],
         },
     )
 

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -144,6 +144,6 @@ def test_text_search_with_semantic_scores(
     # the mock writes the call args into the response tags
     assert results[0].tags['parameters']['semantic_scores']
     assert results[0].tags['parameters']['semantic_scores'] == [
-        ['text_0', 'image_0', 'clip', 1],
+        ['text_0', 'product_image', 'clip', 1],
         ['text_0', 'bm25_text', 'bm25', 1],
     ]

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -129,3 +129,6 @@ def test_text_search_with_semantic_scores(
     results = DocumentArray.from_json(response.content)
     # the mock writes the call args into the response tags
     assert results[0].tags['parameters']['semantic_scores']
+    assert results[0].tags['parameters']['semantic_scores'] == [
+        ['text_0', 'text', 'clip', 1]
+    ]

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -133,7 +133,7 @@ def test_text_search_with_semantic_scores(
                 {'name': 'text', 'value': 'this crazy text', 'modality': 'text'},
             ],
             'semantic_scores': [
-                ['text', 'image.png', 'clip', 1],
+                ['text', 'product_image', 'clip', 1],
                 ['text', 'bm25_text', 'bm25', 1],
             ],
         },
@@ -144,5 +144,6 @@ def test_text_search_with_semantic_scores(
     # the mock writes the call args into the response tags
     assert results[0].tags['parameters']['semantic_scores']
     assert results[0].tags['parameters']['semantic_scores'] == [
-        ['text_0', 'image_0', 'clip', 1]
+        ['text_0', 'image_0', 'clip', 1],
+        ['text_0', 'bm25_text', 'bm25', 1],
     ]


### PR DESCRIPTION
Previously, when defining semantic scores, one could not define query fields with arbitrary names. The API only accepted semantic scores defined with query fields `'text_0', 'text_1' ...` and `'image_0', 'image_1' ...`. However, the query field in the semantic scores should be allowed to be any string name, as long as it is **consistent** with the name defined in the `'name'` of the query. For example, one would expect that the following snippet works with query field name `'my_query_text'`:

```
import requests

HOST = "<my_host_url>"

request_body = {
    'query': [{'name':'my_query_text', 'modality': 'text', 'value': 'test'}],
    'semantic_scores': [('my_query_text', 'label', 'encoderclip', 1.0)]
 }

response = requests.post('{HOST}/api/v1/search-app/search', json=request_body)
print(response.status_code)
print(response.content)
```

This PR fixes this issue and allows arbitrary query field naming, by mapping this query field name back to the dataclass field that is created for the query document.

Successful customer deployment:
<img width="738" alt="Screenshot 2023-02-24 at 15 09 49" src="https://user-images.githubusercontent.com/55404563/221199300-5cf39ce0-e98c-4a9d-90c3-971e5f4920e5.png">

---

- [x] This PR references an open issue
- [x] Added a test
- [ ] Updated the documentation
- [x] Added a screenshot of a successful customer deployment
