### PR TITLE
refactor: spot instances

### DIFF
--- a/now/app/base/app.py
+++ b/now/app/base/app.py
@@ -118,6 +118,10 @@ class JinaNOWApp:
             'prefetch': PREFETCH_NR,
             'uses_with': {'user_input_dict': user_input.to_safe_dict()},
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
+            'jcloud': {
+                'resources': {'instance': 'C5'},
+                'capacity': 'spot',
+            },
         }
         if 'NOW_EXAMPLES' in os.environ:
             gateway_stub['jcloud'] = {

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -73,7 +73,9 @@ class SearchApp(JinaNOWApp):
             else 'NOWAutoCompleteExecutor2',
             'needs': 'gateway',
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
-            'resources': {'instance': 'C1', 'capacity': 'spot'},
+            'jcloud': {
+                'resources': {'instance': 'C1', 'capacity': 'spot'},
+            },
         }
 
     @staticmethod

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -74,7 +74,8 @@ class SearchApp(JinaNOWApp):
             'needs': 'gateway',
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
             'jcloud': {
-                'resources': {'instance': 'C1', 'capacity': 'spot'},
+                'resources': {'instance': 'C1'},
+                'capacity': 'spot',
             },
         }
 
@@ -93,7 +94,8 @@ class SearchApp(JinaNOWApp):
                     'metric': 'concurrency',
                     'target': 1,
                 },
-                'resources': {'instance': 'C2', 'capacity': 'spot'},
+                'resources': {'instance': 'C2'},
+                'capacity': 'spot',
             },
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
         }
@@ -124,7 +126,8 @@ class SearchApp(JinaNOWApp):
             },
             'jcloud': {
                 'autoscale': {'min': 0, 'max': 5, 'metric': 'concurrency', 'target': 1},
-                'resources': {'instance': 'C6', 'capacity': 'spot'},
+                'resources': {'instance': 'C6'},
+                'capacity': 'spot',
             },
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
         }, 768
@@ -175,7 +178,8 @@ class SearchApp(JinaNOWApp):
                     'app': 'indexer',
                     'provision-index': provision_index,
                 },
-                'resources': {'instance': 'C6', 'capacity': 'spot'},
+                'resources': {'instance': 'C6'},
+                'capacity': 'spot',
             },
         }
 

--- a/now/app/search_app/app.py
+++ b/now/app/search_app/app.py
@@ -73,6 +73,7 @@ class SearchApp(JinaNOWApp):
             else 'NOWAutoCompleteExecutor2',
             'needs': 'gateway',
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
+            'resources': {'instance': 'C1', 'capacity': 'spot'},
         }
 
     @staticmethod
@@ -90,9 +91,7 @@ class SearchApp(JinaNOWApp):
                     'metric': 'concurrency',
                     'target': 1,
                 },
-                'resources': {
-                    'instance': 'C2',
-                },
+                'resources': {'instance': 'C2', 'capacity': 'spot'},
             },
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
         }
@@ -123,9 +122,7 @@ class SearchApp(JinaNOWApp):
             },
             'jcloud': {
                 'autoscale': {'min': 0, 'max': 5, 'metric': 'concurrency', 'target': 1},
-                'resources': {
-                    'instance': 'C6',
-                },
+                'resources': {'instance': 'C6', 'capacity': 'spot'},
             },
             'env': {'JINA_LOG_LEVEL': 'DEBUG'},
         }, 768
@@ -176,9 +173,7 @@ class SearchApp(JinaNOWApp):
                     'app': 'indexer',
                     'provision-index': provision_index,
                 },
-                'resources': {
-                    'instance': 'C6',
-                },
+                'resources': {'instance': 'C6', 'capacity': 'spot'},
             },
         }
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -5,7 +5,7 @@ from docarray.typing import Image, Text, Video
 from now.utils import BetterEnum
 
 NOW_GATEWAY_VERSION = '0.0.4-fix-custom-gateway-remote-4'
-NOW_PREPROCESSOR_VERSION = '0.0.123-test-use-setup-25'
+NOW_PREPROCESSOR_VERSION = '0.0.124-refactor-spot-instances-1'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.147-feat-integrate-elastic-manager-17'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-refactor-custom-gateway-103'
 


### PR DESCRIPTION
latest wolf update defaults to on-demand instances, but we should only use spot instances