### PR TITLE
fix: fix pandas for compare flows

### DIFF
--- a/now/constants.py
+++ b/now/constants.py
@@ -4,10 +4,10 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-pandas-req-1'
-NOW_PREPROCESSOR_VERSION = '0.0.124-fix-pandas-req-1'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-pandas-req-1'
-NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-pandas-req-1'
+NOW_GATEWAY_VERSION = '0.0.4-fix-pandas-req-2'
+NOW_PREPROCESSOR_VERSION = '0.0.124-fix-pandas-req-2'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-pandas-req-2'
+NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-pandas-req-2'
 
 
 class Apps(BetterEnum):

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,10 +4,10 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-feat-get-flow-emails-0'
-NOW_PREPROCESSOR_VERSION = '0.0.124-feat-get-flow-emails-0'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.148-feat-get-flow-emails-0'
-NOW_AUTOCOMPLETE_VERSION = '0.0.11-feat-get-flow-emails-0'
+NOW_GATEWAY_VERSION = '0.0.4-fix-pandas-req'
+NOW_PREPROCESSOR_VERSION = '0.0.124-fix-pandas-req'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-pandas-req'
+NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-pandas-req'
 
 
 class Apps(BetterEnum):

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,10 +4,10 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.4-fix-pandas-req'
-NOW_PREPROCESSOR_VERSION = '0.0.124-fix-pandas-req'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-pandas-req'
-NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-pandas-req'
+NOW_GATEWAY_VERSION = '0.0.4-fix-pandas-req-1'
+NOW_PREPROCESSOR_VERSION = '0.0.124-fix-pandas-req-1'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-pandas-req-1'
+NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-pandas-req-1'
 
 
 class Apps(BetterEnum):

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,8 +13,6 @@ fast-autocomplete==0.9.0
 Levenshtein==0.20.5
 python-Levenshtein==0.20.5
 better_profanity==0.7.0
-filetype
-streamlit==1.16.0
 extra-streamlit-components==0.1.55
 click==8.0.0
 fastapi==0.78.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ elasticsearch==8.4.1
 pydantic==1.9.2
 httpx==0.23.2
 av==9.1.1
+pandas==1.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ pydantic==1.9.2
 httpx==0.23.2
 av==9.1.1
 pandas==1.3.5
+streamlit==1.16.0
+filetype==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ elasticsearch==8.4.1
 pydantic==1.9.2
 httpx==0.23.2
 av==9.1.1
-pandas==1.4.2
+pandas==1.3.5


### PR DESCRIPTION
Fixes that installation from source without installing `requirements-test.txt` is causing an error.


---

- [ ] This PR references an open issue
- [ ] Added a test
- [ ] Updated the documentation
- [ ] Added a screenshot of a successful customer deployment
