### PR TITLE
fix: user input bff

### DIFF
--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.5-fix-shared-user-input-bff-2'
+NOW_GATEWAY_VERSION = '0.0.5-fix-shared-user-input-bff-3'
 NOW_PREPROCESSOR_VERSION = '0.0.124-fix-pandas-req-2'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.148-fix-pandas-req-2'
 NOW_AUTOCOMPLETE_VERSION = '0.0.11-fix-pandas-req-2'

--- a/now/executor/gateway/bff/app/settings.py
+++ b/now/executor/gateway/bff/app/settings.py
@@ -39,8 +39,11 @@ DEFAULT_LOGGING_CONFIG = {
 }
 
 
-def get_user_input_in_bff():
-    user_input_in_bff = UserInput()
+user_input_in_bff = UserInput()
+
+
+def init_user_input_in_bff():
+    global user_input_in_bff
     try:
         with open(os.path.join(os.path.expanduser('~'), 'user_input.json'), 'r') as f:
             user_input_dict = json.load(f)
@@ -54,4 +57,6 @@ def get_user_input_in_bff():
         print('Could not find user input file in BFF')
         print(f'used path: {os.path.join(os.path.expanduser("~"), "user_input.json")}')
         print('but this can be okay')
-    return user_input_in_bff
+
+
+init_user_input_in_bff()

--- a/now/executor/gateway/bff/app/v1/routers/info.py
+++ b/now/executor/gateway/bff/app/v1/routers/info.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from docarray import Document
 from fastapi import APIRouter
 
-from now.executor.gateway.bff.app.settings import get_user_input_in_bff
+from now.executor.gateway.bff.app.settings import user_input_in_bff
 from now.executor.gateway.bff.app.v1.models.info import (
     CountRequestModel,
     CountResponseModel,
@@ -43,14 +43,13 @@ async def get_count(data: CountRequestModel) -> CountResponseModel:
 @router.post('/field_names_to_dataclass_fields')
 async def get_field_names_to_dataclass_fields() -> FieldNamesToDataclassFieldsResponseModel:
     return FieldNamesToDataclassFieldsResponseModel(
-        field_names_to_dataclass_fields=get_user_input_in_bff().field_names_to_dataclass_fields
+        field_names_to_dataclass_fields=user_input_in_bff.field_names_to_dataclass_fields
     )
 
 
 @router.post('/encoder_to_dataclass_fields_mods')
 async def get_index_fields_dict() -> EncoderToDataclassFieldsModsResponseModel:
     index_fields_dict = defaultdict(dict)
-    user_input_in_bff = get_user_input_in_bff()
     for index_field_raw, encoders in user_input_in_bff.model_choices.items():
         index_field = index_field_raw.replace('_model', '')
         dataclass_field = user_input_in_bff.field_names_to_dataclass_fields[index_field]

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -5,7 +5,7 @@ from docarray import Document
 from fastapi import APIRouter, Body
 
 from now.data_loading.create_dataclass import create_dataclass
-from now.executor.gateway.bff.app.settings import get_user_input_in_bff
+from now.executor.gateway.bff.app.settings import user_input_in_bff
 from now.executor.gateway.bff.app.v1.models.search import (
     SearchRequestModel,
     SearchResponseModel,
@@ -202,7 +202,6 @@ def get_semantic_scores(
         [['query_text', 'my_product_image', 'encoderclip', 1], ['query_text', 'bm25_text', 'bm25', 1]]
     """
     semantic_scores = []
-    user_input_in_bff = get_user_input_in_bff()
     for sem_score in data.semantic_scores:
         sem_score = list(sem_score)
         sem_score[0] = field_names_to_dataclass_fields[sem_score[0]]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,6 +154,7 @@ def es_connection_params():
     connection_args = {'verify_certs': False}
     return connection_str, connection_args
 
+
 @pytest.fixture(scope="function")
 def dump_user_input(request) -> None:
     # If user_input.json exists, then remove it

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,13 +154,16 @@ def es_connection_params():
     connection_args = {'verify_certs': False}
     return connection_str, connection_args
 
-
-@pytest.fixture
-def mock_bff_user_input(request, mocker) -> None:
-    mocker.patch(
-        'now.executor.gateway.bff.app.settings.get_user_input_in_bff',
-        lambda: request.param,
-    )
+@pytest.fixture(scope="function")
+def dump_user_input(request) -> None:
+    # If user_input.json exists, then remove it
+    if os.path.exists(os.path.join(os.path.expanduser('~'), 'user_input.json')):
+        os.remove(os.path.join(os.path.expanduser('~'), 'user_input.json'))
+    # Now dump the user input
+    with open(os.path.join(os.path.expanduser('~'), 'user_input.json'), 'w') as f:
+        json.dump(request.param.__dict__, f)
+    yield
+    os.remove(os.path.join(os.path.expanduser('~'), 'user_input.json'))
 
 
 @pytest.fixture(scope='session')

--- a/tests/integration/offline_flow/test_offline_flow.py
+++ b/tests/integration/offline_flow/test_offline_flow.py
@@ -20,10 +20,10 @@ def get_user_input():
     return user_input
 
 
-@pytest.mark.parametrize('mock_bff_user_input', [get_user_input()], indirect=True)
+@pytest.mark.parametrize('dump_user_input', [get_user_input()], indirect=True)
 @pytest.mark.asyncio
 async def test_docarray(
-    mock_bff_user_input,
+    dump_user_input,
     monkeypatch,
     setup_service_running,
     random_index_name,

--- a/tests/unit/bff/conftest.py
+++ b/tests/unit/bff/conftest.py
@@ -57,6 +57,7 @@ def client_with_mocked_jina_client(
 ) -> Callable[[DocumentArray], requests.Session]:
     def _fixture(response: DocumentArray) -> requests.Session:
         from now.executor.gateway.bff.app.app import build_app
+        from now.executor.gateway.bff.app.settings import init_user_input_in_bff
 
         def _get_jina_streamer():
             return MockedJinaClient(response)
@@ -66,6 +67,7 @@ def client_with_mocked_jina_client(
             _get_jina_streamer,
         )
 
+        init_user_input_in_bff()
         return TestClient(build_app())
 
     return _fixture

--- a/tests/unit/bff/v1/routers/test_info.py
+++ b/tests/unit/bff/v1/routers/test_info.py
@@ -57,9 +57,9 @@ def get_user_input() -> UserInput:
     return user_input
 
 
-@pytest.mark.parametrize('mock_bff_user_input', [get_user_input()], indirect=True)
+@pytest.mark.parametrize('dump_user_input', [get_user_input()], indirect=True)
 def test_field_names_to_dataclass_fields_response(
-    mock_bff_user_input,
+    dump_user_input,
     client_with_mocked_jina_client: Callable[[DocumentArray], requests.Session],
     sample_search_response_text: DocumentArray,
     base64_image_string: str,

--- a/tests/unit/bff/v1/routers/test_search.py
+++ b/tests/unit/bff/v1/routers/test_search.py
@@ -119,9 +119,9 @@ def get_user_input() -> UserInput:
     return user_input
 
 
-@pytest.mark.parametrize('mock_bff_user_input', [get_user_input()], indirect=True)
+@pytest.mark.parametrize('dump_user_input', [get_user_input()], indirect=True)
 def test_text_search_with_semantic_scores(
-    mock_bff_user_input,
+    dump_user_input,
     client_with_mocked_jina_client: Callable[[DocumentArray], requests.Session],
     sample_search_response_text: DocumentArray,
     base64_image_string: str,


### PR DESCRIPTION

Make user_input_in_bff global and initialize it in mocked client everytime so that the user_input.json is loaded properly with the correct values


---

- [ ] This PR references an open issue
- [ ] Added a test
- [ ] Updated the documentation
- [ ] Added a screenshot of a successful customer deployment
