### PR TITLE
feat: allow multiple filters

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -13,3 +13,5 @@ coverage:
     require_changes: false  # if true: only post the comment if coverage changes
     branches:               # branch names that can post comment
       - "main"
+ignore:
+  - "now/executor/gateway/playground/playground.py"

--- a/docs/user-guides/cli_api.md
+++ b/docs/user-guides/cli_api.md
@@ -110,8 +110,12 @@ Optional parameters:
 
   - **limit**: set the number of results in the response
     - example: `5`
-  - **filters**: a dictionary of filters, with filter name as key and target as value
-    - example: `{'tags__color': {'$eq': 'blue'}, 'tags__price': {'$gt': 100}}`
+  - **filters**: a dictionary of filters, with filter name as key and target as value. The target should be a list of strings
+    in the case of categorical filters, and a dictionary with operators as keys and floats or integers as values in the case
+    of numerical filters. See the
+    [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-range-query.html)
+    for more information on range queries and allowed operators.
+    - example: `{'tags__color': ['blue'], 'tags__price': {'gt': 100, 'lte': 200}}`
   - **score_calculation**: list of score calculation components defining how fields should be compared and weighted. Each score calculation
         must contain 4 items, the query field and index field, the encoding model used to create representations
         for both fields, and the weight this score should have in the overall calculation, ranging between 0 and 1.

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-2'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-3'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-2'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-3'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-6'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-7'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-6'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-7'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-5'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-6'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-5'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-6'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-3'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-4'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-3'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-4'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-1'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-2'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-1'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-2'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-alternative-hubble-report-15'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-0'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-alternative-hubble-report-15'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-0'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-4'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-5'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-4'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-5'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-0'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-1'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-alternative-hubble-report-15'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-0'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-1'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-alternative-hubble-report-15'
 
 

--- a/now/constants.py
+++ b/now/constants.py
@@ -4,9 +4,9 @@ from docarray.typing import Image, Text, Video
 
 from now.utils import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-7'
+NOW_GATEWAY_VERSION = '0.0.6-feat-multi-filter-8'
 NOW_PREPROCESSOR_VERSION = '0.0.125-feat-dns-for-demo-2'
-NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-7'
+NOW_ELASTIC_INDEXER_VERSION = '0.0.149-feat-multi-filter-8'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-feat-dns-for-demo-2'
 
 

--- a/now/executor/gateway/bff/app/v1/models/search.py
+++ b/now/executor/gateway/bff/app/v1/models/search.py
@@ -29,7 +29,7 @@ class SearchRequestModel(BaseRequestModel):
     filters: Optional[Dict[str, Union[List, Dict[str, int]]]] = Field(
         default={},
         description='dictionary with filters for search results',
-        example={'tags__color': ['blue'], 'tags__price': {'lt': 50.0}},
+        example={'color': ['blue'], 'price': {'lt': 50.0}},
     )
     query: List[Dict] = Field(
         default={},
@@ -85,7 +85,7 @@ class SearchResponseModel(BaseModel):
         ]
     ] = Field(
         description='Additional tags associated with the file.',
-        example={'tags__price': {'$lt': 50.0}},
+        example={'price': {'$lt': 50.0}},
     )
     fields: Dict[str, ModalityModel] = Field(
         default={},

--- a/now/executor/gateway/bff/app/v1/models/search.py
+++ b/now/executor/gateway/bff/app/v1/models/search.py
@@ -26,10 +26,10 @@ class SearchRequestModel(BaseRequestModel):
     limit: int = Field(
         default=10, description='Number of matching results to return', example=10
     )
-    filters: Optional[Dict[str, str]] = Field(
+    filters: Optional[Dict[str, Union[List, Dict[str, int]]]] = Field(
         default={},
         description='dictionary with filters for search results',
-        example={'tags__color': {'$eq': 'blue'}},
+        example={'tags__color': ['blue'], 'tags__price': {'lt': 50.0}},
     )
     query: List[Dict] = Field(
         default={},

--- a/now/executor/gateway/bff/app/v1/models/search.py
+++ b/now/executor/gateway/bff/app/v1/models/search.py
@@ -26,7 +26,7 @@ class SearchRequestModel(BaseRequestModel):
     limit: int = Field(
         default=10, description='Number of matching results to return', example=10
     )
-    filters: Optional[Dict[str, Union[List, Dict[str, int]]]] = Field(
+    filters: Optional[Dict[str, Union[List, Dict[str, Union[int, float]]]]] = Field(
         default={},
         description='dictionary with filters for search results',
         example={'color': ['blue'], 'price': {'lt': 50.0}},
@@ -85,7 +85,7 @@ class SearchResponseModel(BaseModel):
         ]
     ] = Field(
         description='Additional tags associated with the file.',
-        example={'price': {'$lt': 50.0}},
+        example={'price': {'lt': 50.0}},
     )
     fields: Dict[str, ModalityModel] = Field(
         default={},

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -62,8 +62,8 @@ search_examples = {
         'value': {
             'limit': 10,
             'filters': {
-                'tags__color': ['blue', 'red'],
-                'tags__price': {'lte': 100, 'gte': 50},
+                'color': ['blue', 'red'],
+                'price': {'lte': 100, 'gte': 50},
             },
             'query': [
                 {

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -132,7 +132,7 @@ async def search(
 
     query_filter = {}
     for key, value in data.filters.items():
-        key = 'tags__' + key if not key.startswith('tags__') else key
+        key = 'tags__' + key
         query_filter[key] = value
 
     docs = await jina_client_post(

--- a/now/executor/gateway/bff/app/v1/routers/search.py
+++ b/now/executor/gateway/bff/app/v1/routers/search.py
@@ -62,8 +62,8 @@ search_examples = {
         'value': {
             'limit': 10,
             'filters': {
-                'tags__color': {'$eq': 'blue'},
-                'tags__price': {'$lte': 100, '$gte': 50},
+                'tags__color': ['blue', 'red'],
+                'tags__price': {'lte': 100, 'gte': 50},
             },
             'query': [
                 {
@@ -133,7 +133,7 @@ async def search(
     query_filter = {}
     for key, value in data.filters.items():
         key = 'tags__' + key if not key.startswith('tags__') else key
-        query_filter[key] = {'$eq': value}
+        query_filter[key] = value
 
     docs = await jina_client_post(
         endpoint='/search',

--- a/now/executor/gateway/playground/playground.py
+++ b/now/executor/gateway/playground/playground.py
@@ -3,6 +3,7 @@ import gc
 import io
 import json
 import os
+import traceback
 from typing import List
 from urllib.parse import quote
 from urllib.request import urlopen
@@ -121,7 +122,7 @@ def deploy_streamlit(user_input: UserInput):
                 user_input.field_names_to_dataclass_fields
             )
 
-        apply_filters(params)
+        render_filters(params)
         render_input_boxes()
         customize_score_calculation()
         toggle_score_breakdown()
@@ -167,13 +168,14 @@ def process_filters():
     st.session_state.filter_selection = processed_filters
 
 
-def apply_filters(params):
+def render_filters(params):
     if not st.session_state.tags:
         try:
             tags = get_info_from_endpoint(params, endpoint='tags')
             st.session_state.tags = tags
-        except Exception as e:
-            print("Filters couldn't be loaded from the endpoint properly.", e)
+        except Exception:
+            print("Filters couldn't be loaded from the endpoint properly.")
+            traceback.format_exc()
 
     if st.session_state.tags:
         st.sidebar.title('Filters')
@@ -188,7 +190,6 @@ def apply_filters(params):
                 st.session_state.filter_selection[tag] = st.sidebar.multiselect(
                     tag, values
                 )
-            print(st.session_state.filter_selection[tag])
         st.session_state.filters_set = True
 
     process_filters()

--- a/now/executor/indexer/elastic/es_query_building.py
+++ b/now/executor/indexer/elastic/es_query_building.py
@@ -201,16 +201,16 @@ def process_filter(
     filter: Dict[str, Union[List[str], Dict[str, float]]]
 ) -> List[Dict[str, Any]]:
     es_search_filters = []
-    for field, filter in filter.items():
-        field = field.replace('__', '.')
+    for field, filters in filter.items():
+        field = field.replace('__', '.', 1)
         es_search_filter = {}
-        if isinstance(filter, list):  # must be categorical (list of terms)
-            es_search_filter['terms'] = {field: filter}
-        elif isinstance(filter, dict):  # must be numerical (range with operators)
-            es_search_filter['range'] = {field: filter}
+        if isinstance(filters, list):  # must be categorical (list of terms)
+            es_search_filter['terms'] = {field: filters}
+        elif isinstance(filters, dict):  # must be numerical (range with operators)
+            es_search_filter['range'] = {field: filters}
         else:
             raise ValueError(
-                f'Filter {field}: {filter} is not a list of terms or a dictionary of ranges'
+                f'Filter {field}: {filters} is not a list of terms or a dictionary of ranges'
             )
         es_search_filters.append(es_search_filter)
     return es_search_filters

--- a/tests/executor/indexer/test_elastic_in_flow.py
+++ b/tests/executor/indexer/test_elastic_in_flow.py
@@ -163,7 +163,7 @@ class TestElasticIndexer:
             on='/search',
             inputs=docs_query,
             return_results=True,
-            parameters={'filter': {'tags__price': {'$lt': 50.0}}},
+            parameters={'filter': {'tags__price': {'lt': 50.0}}},
         )
         assert all([m.tags['price'] < 50 for m in query_res[0].matches])
 
@@ -175,7 +175,7 @@ class TestElasticIndexer:
         assert len(listed_docs) == NUMBER_OF_DOCS
         flow.post(
             on='/delete',
-            parameters={'filter': {'tags__parent_tag': {'$eq': 'different_value'}}},
+            parameters={'filter': {'tags__parent_tag': ['different_value']}},
         )
         listed_docs = flow.post(on='/list', return_results=True)
         assert len(listed_docs) == NUMBER_OF_DOCS - 1
@@ -199,7 +199,7 @@ class TestElasticIndexer:
         )
         flow.post(
             on='/delete',
-            parameters={'filter': {'tags__color': {'$eq': 'blue'}}},
+            parameters={'filter': {'tags__color': ['blue']}},
         )
         response = flow.post(on='/tags')
         assert response[0].text == 'tags'
@@ -208,7 +208,7 @@ class TestElasticIndexer:
         assert 'blue' not in response[0].tags['tags']['color']
         flow.post(
             on='/delete',
-            parameters={'filter': {'tags__greeting': {'$eq': 'hello'}}},
+            parameters={'filter': {'tags__greeting': ['hello']}},
         )
         response = flow.post(on='/tags')
         assert 'hello' not in response[0].tags['tags']['greeting']
@@ -359,11 +359,11 @@ class TestElasticIndexer:
             parameters={
                 'query_to_filter': {
                     'query_1': [
-                        {'title': {'$eq': 'parent_1'}},
-                        {'tags__color': {'$eq': 'red'}},
+                        {'title': ['parent_1']},
+                        {'tags__color': ['red']},
                     ],
                     'query_2': [
-                        {'title': {'$eq': 'parent_2'}},
+                        {'title': ['parent_2']},
                     ],
                 }
             },

--- a/tests/executor/indexer/test_es_query_building.py
+++ b/tests/executor/indexer/test_es_query_building.py
@@ -96,5 +96,4 @@ def test_filter_processing(filters, error):
             process_filter(filters)
     else:
         processed_filters = process_filter(filters)
-        print(processed_filters)
         assert list(processed_filters[0].keys())[0].count("__") == 0

--- a/tests/integration/local/test_custom_da_with_tags.py
+++ b/tests/integration/local/test_custom_da_with_tags.py
@@ -26,7 +26,7 @@ def test_search_filters(get_flow, setup_service_running):
     )
     request_body = get_request_body(secured=False)
     request_body['query'] = [{'name': 'text', 'value': 'test', 'modality': 'text'}]
-    request_body['filters'] = {'color': 'Blue Color'}
+    request_body['filters'] = {'color': ['Blue Color']}
     response = requests.post(
         SEARCH_URL,
         json=request_body,


### PR DESCRIPTION
<!--- Please add PR Description here --->
Enabling multiple filters sent in the search request. Slight change to the filter parameter, also updated the documentation for NOW and API documentation to reflect new format. 

Note that numerical and categorical filters now have different input fields in the playground: if a filter has numerical information (eg. price, size -> `float` or `int`), then we use a range slider with min + max values. If the filter has categorical information (eg. color, category -> `str`), then we use a multiselect field where multiple values can be selected.

<img width="337" alt="Screenshot 2023-03-10 at 15 18 42" src="https://user-images.githubusercontent.com/55404563/224339641-0223b665-b04f-4bfd-9815-c23affddcd19.png">

As for the API request body with a filter, this is what it should look like:

```
{
  "filters": {
    "color": ["blue", "red"],
    "price": {"lte": 100, "gte": 50}
  },
  "query": [
    ...
  ],
  "create_temp_link": false,
  "score_calculation": [
   ...
  ]
}
```

For more info on which operators are supported by Elasticsearch in range queries (ie. for numerical filters), see [this documentation](https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-range-query.html).

Successful customer deployment using filters for query:

<img width="1536" alt="Screenshot 2023-03-10 at 15 15 13" src="https://user-images.githubusercontent.com/55404563/224340501-367a9b3b-7844-47df-a79f-47720ef731d6.png">


---

- [x] This PR references an open issue
- [x] Added a test
- [x] Updated the documentation
- [x] Added a screenshot of a successful customer deployment
