### PR TITLE
fix: use session token

### DIFF
--- a/now/constants.py
+++ b/now/constants.py
@@ -4,7 +4,7 @@ from docarray.typing import Image, Text, Video
 
 from now.utils.common.helpers import BetterEnum
 
-NOW_GATEWAY_VERSION = '0.0.6-fix-m2m-token-29'
+NOW_GATEWAY_VERSION = '0.0.6-fix-session-token-0'
 NOW_PREPROCESSOR_VERSION = '0.0.125-fix-m2m-token-29'
 NOW_ELASTIC_INDEXER_VERSION = '0.0.149-fix-m2m-token-29'
 NOW_AUTOCOMPLETE_VERSION = '0.0.12-fix-m2m-token-29'

--- a/now/now_dataclasses.py
+++ b/now/now_dataclasses.py
@@ -46,6 +46,7 @@ class UserInput(BaseModel):
     cluster: Optional[str] = None
     secured: Optional[StrictBool] = False
     jwt: Optional[Dict[str, str]] = None
+    user_id: Optional[str] = None
     admin_name: Optional[str] = None
     admin_emails: Optional[List[str]] = None
     user_emails: Optional[List[str]] = None

--- a/now/utils/authentication/helpers.py
+++ b/now/utils/authentication/helpers.py
@@ -43,4 +43,5 @@ def get_info_hubble(user_input):
         )
     user_input.jwt = {'token': client.token}
     user_input.admin_name = response['data']['name']
+    user_input.user_id = response['data']['_id']
     return response['data'], client.token


### PR DESCRIPTION
<!--- Please add PR Description here --->

The current implementation of m2m token relies on storage being attached to the gateway, however this is not supported yet from JCloud. So, in case of pod restart, the `authorized_jwt` would be lost and if the user_token passed in `uses_with` expires then the billing won't work. Hence, we use an impersonation token, which is a fixed value per user per app and has no expiry date and to obtain this we need only user id and m2m token, hence we give up our dependency of user_token. We can always rely on impersonation token and treat it as a session token

---

- [ ] This PR references an open issue
- [ ] Added a test
- [ ] Updated the documentation
- [ ] Added a screenshot of a successful customer deployment
